### PR TITLE
feat: remove s3 policy from drupal

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ https://docs.google.com/document/d/1-2-MSpd-g_i5UjxHVkZW8wpKUZORjLrzd8A-UhW2XAY/
 | [aws_s3_bucket_server_side_encryption_configuration.terraform_state_crypto_conf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.terraform_state_bucket_versioning](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [digitalocean_spaces_bucket.drupal](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/spaces_bucket) | resource |
-| [digitalocean_spaces_bucket_policy.example_policy](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/spaces_bucket_policy) | resource |
 | [github_actions_secret.SSH_HOST_PROD](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |
 | [github_actions_secret.SSH_HOST_STAGE](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |
 | [github_actions_secret.SSH_PRIVATE_KEY](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |

--- a/s3_buckets.tf
+++ b/s3_buckets.tf
@@ -2,20 +2,3 @@ resource "digitalocean_spaces_bucket" "drupal" {
   name   = "drupal"
   region = "nyc3"
 }
-
-resource "digitalocean_spaces_bucket_policy" "example_policy" {
-  bucket = digitalocean_spaces_bucket.drupal.name
-  region = digitalocean_spaces_bucket.drupal.region
-  policy = jsonencode({
-    "Version" : "2012-10-17",
-    "Statement" : [
-      {
-        "Sid" : "PrivateAccess",
-        "Effect" : "Deny",
-        "Principal" : "*",
-        "Action" : "s3:GetObject",
-        "Resource" : "arn:aws:s3:::${digitalocean_spaces_bucket.drupal.name}/private/*"
-      }
-    ]
-  })
-}


### PR DESCRIPTION
This policy is not needed since drupal s3fs sets permissions on private files