### PR TITLE
fix: move from github_issue_labels to github_issue_label

### DIFF
--- a/default_github_labels_module/main.tf
+++ b/default_github_labels_module/main.tf
@@ -11,66 +11,86 @@ provider "github" {
   owner = "gpo"
 }
 
-resource "github_issue_labels" "labels" {
-  repository = var.repository
-
-  label {
-    name        = "Epic"
-    description = "A large project that needs to be broken into parts"
-    color       = "5319E7"
+locals {
+  colors = {
+    repo_specific_color   = "0e8a16"
+    who_should_work_on_it = "fbca04"
   }
+}
 
-  label {
-    color       = "0075ca"
-    description = "Improvements or additions to documentation"
-    name        = "documentation"
-  }
+resource "github_issue_label" "epic" {
+  repository  = var.repository
+  name        = "Epic"
+  description = "A large project that needs to be broken into parts"
+  color       = "5319E7"
+}
 
-  label {
-    color       = "008672"
-    description = "Extra attention is needed"
-    name        = "help wanted"
-  }
+resource "github_issue_label" "enhancement" {
+  repository  = var.repository
+  name        = "enhancement"
+  description = "New feature or request"
+  color       = "a2eeef"
+}
 
-  label {
-    color       = "7057ff"
-    description = "Good for newcomers"
-    name        = "good first issue"
-  }
+resource "github_issue_label" "bug" {
+  repository  = var.repository
+  name        = "bug"
+  description = "Something isn't working"
+  color       = "d73a4a"
+}
 
-  label {
-    color       = "a2eeef"
-    description = "New feature or request"
-    name        = "enhancement"
-  }
+resource "github_issue_label" "documentation" {
+  repository  = var.repository
+  name        = "documentation"
+  description = "Improvements or additions to documentation"
+  color       = "0075ca"
+}
 
-  label {
-    color       = "cfd3d7"
-    description = "This issue or pull request already exists"
-    name        = "duplicate"
-  }
+resource "github_issue_label" "question" {
+  repository  = var.repository
+  name        = "question"
+  description = "Further information is requested"
+  color       = "d876e3"
+}
 
-  label {
-    color       = "d73a4a"
-    description = "Something isn't working"
-    name        = "bug"
-  }
+resource "github_issue_label" "invalid" {
+  repository  = var.repository
+  name        = "invalid"
+  description = "This doesn't seem right"
+  color       = "e4e669"
+}
 
-  label {
-    color       = "d876e3"
-    description = "Further information is requested"
-    name        = "question"
-  }
+resource "github_issue_label" "wontfix" {
+  repository  = var.repository
+  name        = "wontfix"
+  description = "This will not be worked on"
+  color       = "ffffff"
+}
 
-  label {
-    color       = "e4e669"
-    description = "This doesn't seem right"
-    name        = "invalid"
-  }
+resource "github_issue_label" "duplicate" {
+  repository  = var.repository
+  name        = "duplicate"
+  description = "This issue or pull request already exists"
+  color       = "cfd3d7"
+}
 
-  label {
-    color       = "ffffff"
-    description = "This will not be worked on"
-    name        = "wontfix"
-  }
+resource "github_issue_label" "help_wanted" {
+  repository  = var.repository
+  name        = "help wanted"
+  description = "Extra attention is needed"
+  color       = local.colors.who_should_work_on_it
+}
+
+resource "github_issue_label" "good_first_issue" {
+  repository  = var.repository
+  name        = "good first issue"
+  description = "Good for newcomers"
+  color       = local.colors.who_should_work_on_it
+}
+
+resource "github_issue_label" "volunteer" {
+  repository  = var.repository
+  name        = "volunteer"
+  description = "Good issue for a volunteer"
+  color       = local.colors.who_should_work_on_it
 }


### PR DESCRIPTION
`github_issue_labels` always destroys and recreates labels when anything changes, where as `github_issue_label` keys on `name`.

This PR migrates from `github_issue_labels` to `github_issue_label`

This PR also adds the volunteer label
And colors, volunteer, help wanted, and good first issue