### PR TITLE
VPC & EKS

### DIFF
--- a/infra/prod/locals.tf
+++ b/infra/prod/locals.tf
@@ -1,0 +1,7 @@
+locals {
+  project_name           = "gpo"
+  environment            = "prod"
+  nodegroup_desired_size = 2
+  nodegroup_max_size     = 16
+  nodegroup_min_size     = 2
+}

--- a/infra/prod/main.tf
+++ b/infra/prod/main.tf
@@ -1,7 +1,19 @@
-module "eks" {
-  source = "../../modules/infra/eks"
+module "vpc" {
+  source      = "../../modules/infra/vpc"
+  name        = local.project_name
+  environment = local.environment
 }
 
-module "vpc" {
-  source = "../../modules/infra/vpc"
+module "eks" {
+  source                      = "../../modules/infra/eks"
+  name                        = local.project_name
+  environment                 = local.environment
+  public_subnet_ids           = [module.vpc.public_subnet_id]
+  private_active_subnet_ids   = [module.vpc.private_active_subnet_id]
+  private_inactive_subnet_ids = [module.vpc.private_inactive_subnet_id]
+  # TODO: uncomment this once we have bootstrap in the prod AWS account
+  admin_user_arns        = [] #data.terraform_remote_state.bootstrap.outputs.admin_user_arns
+  nodegroup_desired_size = local.nodegroup_desired_size
+  nodegroup_min_size     = local.nodegroup_min_size
+  nodegroup_max_size     = local.nodegroup_max_size
 }

--- a/infra/prod/remote_state.tf
+++ b/infra/prod/remote_state.tf
@@ -1,0 +1,13 @@
+# retrieve the outputs of the bootstrap TF so we can use them as inputs
+
+data "terraform_remote_state" "bootstrap" {
+  backend = "s3"
+  config = {
+    bucket         = "gpo-terraform-state"
+    key            = "bootstrap/terraform.tfstate"
+    region         = "ca-central-1"
+    dynamodb_table = "terraform-state-locks"
+    encrypt        = true
+    profile        = "gpo-stage"
+  }
+}

--- a/infra/stage/locals.tf
+++ b/infra/stage/locals.tf
@@ -1,3 +1,7 @@
 locals {
-  iam_admin_users = ["rsalmond", "Ian_Edington_Laptop"]
+  project_name           = "gpo"
+  environment            = "stage"
+  nodegroup_desired_size = 1
+  nodegroup_max_size     = 5
+  nodegroup_min_size     = 1
 }

--- a/infra/stage/main.tf
+++ b/infra/stage/main.tf
@@ -1,12 +1,18 @@
-module "iam_users" {
-  source          = "../../modules/infra/iam_users"
-  iam_admin_users = local.iam_admin_users
+module "vpc" {
+  source      = "../../modules/infra/vpc"
+  name        = local.project_name
+  environment = local.environment
 }
 
 module "eks" {
-  source = "../../modules/infra/eks"
-}
-
-module "vpc" {
-  source = "../../modules/infra/vpc"
+  source                      = "../../modules/infra/eks"
+  name                        = local.project_name
+  environment                 = local.environment
+  public_subnet_ids           = [module.vpc.public_subnet_id]
+  private_active_subnet_ids   = [module.vpc.private_active_subnet_id]
+  private_inactive_subnet_ids = [module.vpc.private_inactive_subnet_id]
+  admin_user_arns             = data.terraform_remote_state.bootstrap.outputs.admin_user_arns
+  nodegroup_desired_size      = local.nodegroup_desired_size
+  nodegroup_min_size          = local.nodegroup_min_size
+  nodegroup_max_size          = local.nodegroup_max_size
 }

--- a/infra/stage/remote_state.tf
+++ b/infra/stage/remote_state.tf
@@ -1,0 +1,13 @@
+# retrieve the outputs of the bootstrap TF so we can use them as inputs
+
+data "terraform_remote_state" "bootstrap" {
+  backend = "s3"
+  config = {
+    bucket         = "gpo-terraform-state"
+    key            = "bootstrap/terraform.tfstate"
+    region         = "ca-central-1"
+    dynamodb_table = "terraform-state-locks"
+    encrypt        = true
+    profile        = "gpo-stage"
+  }
+}

--- a/modules/infra/eks/cluster.tf
+++ b/modules/infra/eks/cluster.tf
@@ -1,0 +1,75 @@
+resource "aws_eks_cluster" "main" {
+
+  name = local.name
+
+  # Ensure that IAM Role permissions are created before and deleted
+  # after EKS Cluster handling. Otherwise, EKS will not be able to
+  # properly delete EKS managed EC2 infrastructure such as Security Groups.
+  depends_on = [
+    aws_iam_role_policy_attachment.cluster,
+    aws_iam_role_policy_attachment.cluster_block_storage,
+    aws_iam_role_policy_attachment.cluster_compute,
+    aws_iam_role_policy_attachment.cluster_lb,
+    aws_iam_role_policy_attachment.cluster_networking
+  ]
+
+  role_arn = aws_iam_role.cluster.arn
+
+  vpc_config {
+    subnet_ids = concat(var.private_active_subnet_ids, var.private_inactive_subnet_ids, var.public_subnet_ids)
+  }
+
+  access_config {
+    # use the Cluster Access API for granting IAM users access to EKS (eg. kubectl)
+    # https://www.eksworkshop.com/docs/security/cluster-access-management/understanding
+    authentication_mode = "API"
+  }
+}
+
+data "aws_iam_policy_document" "cluster_assume_role" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession"
+    ]
+    effect = "Allow"
+    principals {
+      type = "Service"
+      # allow our EKS clusters to use this role
+      identifiers = ["eks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "cluster" {
+  name               = local.name
+  assume_role_policy = data.aws_iam_policy_document.cluster_assume_role.json
+}
+
+# here we use canned EKS cluster policies to grant our cluster the ability
+# to create worker nodes, load balancers, EBS volumes, etc.
+
+resource "aws_iam_role_policy_attachment" "cluster" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.cluster.name
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_compute" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSComputePolicy"
+  role       = aws_iam_role.cluster.name
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_block_storage" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSBlockStoragePolicy"
+  role       = aws_iam_role.cluster.name
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_lb" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSLoadBalancingPolicy"
+  role       = aws_iam_role.cluster.name
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_networking" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSNetworkingPolicy"
+  role       = aws_iam_role.cluster.name
+}

--- a/modules/infra/eks/locals.tf
+++ b/modules/infra/eks/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  name = "${var.name}-${var.environment}"
+}

--- a/modules/infra/eks/main.tf
+++ b/modules/infra/eks/main.tf
@@ -1,1 +1,0 @@
-# cluster, iam roles & policies, eks access entries, security groups, fargate config, cloudwatch log group

--- a/modules/infra/eks/nodes.tf
+++ b/modules/infra/eks/nodes.tf
@@ -1,0 +1,56 @@
+resource "aws_eks_node_group" "main" {
+  cluster_name           = aws_eks_cluster.main.name
+  version                = aws_eks_cluster.main.version
+  node_role_arn          = aws_iam_role.node.arn
+  subnet_ids             = var.private_active_subnet_ids
+  node_group_name_prefix = "${aws_eks_cluster.main.name}-main"
+
+  scaling_config {
+    desired_size = var.nodegroup_desired_size
+    max_size     = var.nodegroup_max_size
+    min_size     = var.nodegroup_min_size
+  }
+
+  # allow nodes to be added / removed without TF plan showing a difference
+  lifecycle {
+    ignore_changes = [scaling_config[0].desired_size]
+  }
+
+}
+
+data "aws_iam_policy_document" "node_assume_role" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+    effect = "Allow"
+    principals {
+      type = "Service"
+      # allow our EC2 instances to use this role
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "node" {
+  name               = "${aws_eks_cluster.main.name}-worker-node"
+  assume_role_policy = data.aws_iam_policy_document.node_assume_role.json
+}
+
+# allow worker nodes to connect to EKS clusters
+resource "aws_iam_role_policy_attachment" "node_eks" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.node.name
+}
+
+# allow CNI plugin to modify IP config of worker nodes
+resource "aws_iam_role_policy_attachment" "node_cni" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.node.name
+}
+
+# allow worker nodes to pull containers from ECR
+resource "aws_iam_role_policy_attachment" "node_ecr_pull" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly"
+  role       = aws_iam_role.node.name
+}

--- a/modules/infra/eks/users.tf
+++ b/modules/infra/eks/users.tf
@@ -1,0 +1,16 @@
+resource "aws_eks_access_entry" "admin" {
+  for_each      = toset(var.admin_user_arns)
+  cluster_name  = aws_eks_cluster.main.name
+  principal_arn = each.value
+}
+
+resource "aws_eks_access_policy_association" "admin" {
+  for_each      = toset(var.admin_user_arns)
+  cluster_name  = aws_eks_cluster.main.name
+  policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+  principal_arn = each.value
+
+  access_scope {
+    type = "cluster"
+  }
+}

--- a/modules/infra/eks/variables.tf
+++ b/modules/infra/eks/variables.tf
@@ -1,0 +1,56 @@
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group#scaling_config-configuration-block
+
+variable "nodegroup_desired_size" {
+  type        = number
+  description = "Number of nodes there should be right now."
+}
+
+variable "nodegroup_min_size" {
+  type        = number
+  description = "Minimum number of nodes to have at any time."
+}
+
+variable "nodegroup_max_size" {
+  type        = number
+  description = "Maximum number of nodes to have at any time."
+}
+
+/*
+Note: EKS clusters MUST be created with subnets in at least two AZs. Since
+we only want this cluster to be in a single AZ we have "active" and "inactive"
+subnets. We give EKS both subnets to satisfy it, but then we will only ever
+create worker nodes in the active subnet.
+*/
+
+variable "private_active_subnet_ids" {
+  type        = list(string)
+  description = "List of active subnet IDs for the cluster."
+}
+
+variable "private_inactive_subnet_ids" {
+  type        = list(string)
+  description = "List of inactive subnet IDs for the cluster."
+}
+
+variable "public_subnet_ids" {
+  type        = list(string)
+  description = "List of public subnet IDs for the cluster."
+}
+
+variable "admin_user_arns" {
+  type        = list(string)
+  description = "List of user ARNs who will get Admin access to the cluster."
+}
+
+variable "name" {
+  type        = string
+  description = "A base name for EKS resources."
+}
+
+variable "environment" {
+  type = string
+  validation {
+    condition     = contains(["prod", "stage"], var.environment)
+    error_message = "Must be one of 'stage' or 'prod'."
+  }
+}

--- a/modules/infra/vpc/locals.tf
+++ b/modules/infra/vpc/locals.tf
@@ -1,0 +1,5 @@
+locals {
+  subnet_active_az   = "ca-central-1a"
+  subnet_inactive_az = "ca-central-1b"
+  name               = "${var.name}-${var.environment}"
+}

--- a/modules/infra/vpc/main.tf
+++ b/modules/infra/vpc/main.tf
@@ -1,1 +1,0 @@
-# VPC, subnets, security groups

--- a/modules/infra/vpc/outputs.tf
+++ b/modules/infra/vpc/outputs.tf
@@ -1,0 +1,15 @@
+output "vpc_id" {
+  value = aws_vpc.main.id
+}
+
+output "public_subnet_id" {
+  value = aws_subnet.public.id
+}
+
+output "private_active_subnet_id" {
+  value = aws_subnet.private_active.id
+}
+
+output "private_inactive_subnet_id" {
+  value = aws_subnet.private_inactive.id
+}

--- a/modules/infra/vpc/private_subnets.tf
+++ b/modules/infra/vpc/private_subnets.tf
@@ -1,0 +1,49 @@
+# --------------------------------------------
+#
+# private subnets
+
+resource "aws_subnet" "private_active" {
+  vpc_id            = aws_vpc.main.id
+  availability_zone = local.subnet_active_az
+
+  # carve out a chunk from the vpc which is 4 bits smaller (/20)
+  cidr_block = cidrsubnet(aws_vpc.main.cidr_block, 4, 1)
+
+
+  tags = {
+    Name = "${local.name}-private-active",
+    # required for EKS to provision LBs
+    "kubernetes.io/role/internal-elb" = 1
+  }
+}
+
+resource "aws_route_table" "private_active" {
+  vpc_id = aws_vpc.main.id
+  tags = {
+    Name = "${local.name}-private-active"
+  }
+}
+
+resource "aws_route_table_association" "private_active" {
+  subnet_id      = aws_subnet.private_active.id
+  route_table_id = aws_route_table.private_active.id
+}
+
+# route traffic leaving private subnet for the internet through the nat gw
+resource "aws_route" "private_active_nat_gw" {
+  route_table_id         = aws_route_table.private_active.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.main.id
+}
+
+resource "aws_subnet" "private_inactive" {
+  vpc_id            = aws_vpc.main.id
+  availability_zone = local.subnet_inactive_az
+
+  # carve out a chunk from the vpc which is 4 bits smaller (/20)
+  cidr_block = cidrsubnet(aws_vpc.main.cidr_block, 4, 2)
+
+  tags = {
+    Name = "${local.name}-private-inactive",
+  }
+}

--- a/modules/infra/vpc/public_subnets.tf
+++ b/modules/infra/vpc/public_subnets.tf
@@ -1,0 +1,58 @@
+# --------------------------------------------
+#
+# public subnet
+
+resource "aws_subnet" "public" {
+  vpc_id            = aws_vpc.main.id
+  availability_zone = local.subnet_active_az
+
+  # carve out a chunk from the vpc which is 4 bits smaller (/20)
+  cidr_block = cidrsubnet(aws_vpc.main.cidr_block, 4, 0)
+
+  tags = {
+    Name = "${local.name}-public"
+    # required for EKS to provision LBs
+    "kubernetes.io/role/elb" = 1
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+  tags = {
+    Name = "${local.name}-public"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+# route traffic originating in public subnet destined for the internet through the internet gw
+resource "aws_route" "public_internet_gateway" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.main.id
+}
+
+# --------------------------------------------
+#
+# nat gateway
+#
+# lives in public subnet, performs NAT for instances in the private subnet so they can reach the internet
+
+resource "aws_eip" "nat_gw" {
+  domain     = "vpc"
+  depends_on = [aws_internet_gateway.main]
+}
+
+resource "aws_nat_gateway" "main" {
+  allocation_id = aws_eip.nat_gw.id
+  subnet_id     = aws_subnet.public.id
+
+  tags = {
+    "Name" = local.name
+  }
+
+  depends_on = [aws_internet_gateway.main]
+}

--- a/modules/infra/vpc/variables.tf
+++ b/modules/infra/vpc/variables.tf
@@ -1,0 +1,12 @@
+variable "name" {
+  type        = string
+  description = "A base name for VPC resources."
+}
+
+variable "environment" {
+  type = string
+  validation {
+    condition     = contains(["prod", "stage"], var.environment)
+    error_message = "Must be one of 'stage' or 'prod'."
+  }
+}

--- a/modules/infra/vpc/vpc.tf
+++ b/modules/infra/vpc/vpc.tf
@@ -1,0 +1,20 @@
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = local.name
+  }
+}
+
+# --------------------------------------------
+#
+# internet gateway
+#
+# lets traffic leave the VPC
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+  tags = {
+    Name = local.name
+  }
+}


### PR DESCRIPTION
Fixes #37

Assumptions:
- the cluster is created in a single availability zone
   - this reduces robustness in the face of outages, but reduces interzone egress fees

This change adds:
- config change for the TF pre-commit hooks to ensure we always include checksums in the lock files for macos and linux on amd64 and arm64
- adds a VPC module which creates VPC, subnets, gateways, routes for basic connectivity
   - we have 2 private subnets in two AZs (one active, one inactive, details documented [here](https://github.com/gpo/gpo-platform-configs/pull/41/files#diff-7fba22d5fee597a14637cb755b1800b73c79d7aa6abfbf44ebb1c3b1be60ceb1R19).
   - we have 1 public subnet
   - all subnet-to-subnet traffic is permitted
   - all outbound traffic is permitted
   - all inbound traffic to the public subnet is permitted
- moves IAM user setup into bootstrap (to avoid nuking ourselves as we destroy/apply stage env)
- adds a Remote State resource so the infra TF can access the outputs of the bootstrap TF (allowing us to get a list of IAM users who need EKS access)
- adds an EKS module which creates a cluster, nodepool, corresponding IAM roles, and grants IAM users access to the cluster
   - all worker nodes go in the private-active subnet (they never get a public IP)
   - all load balancers go in the public subnet

Uses:
- https://github.com/terraform-aws-modules/terraform-aws-eks
- https://github.com/terraform-aws-modules/terraform-aws-vpc