### PR TITLE
Capture IAM users in TF

### DIFF
--- a/infra/stage/locals.tf
+++ b/infra/stage/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  iam_admin_users = ["rsalmond", "Ian_Edington_Laptop"]
+}

--- a/infra/stage/main.tf
+++ b/infra/stage/main.tf
@@ -1,3 +1,8 @@
+module "iam_users" {
+  source          = "../../modules/infra/iam_users"
+  iam_admin_users = local.iam_admin_users
+}
+
 module "eks" {
   source = "../../modules/infra/eks"
 }

--- a/modules/infra/iam_users/main.tf
+++ b/modules/infra/iam_users/main.tf
@@ -1,0 +1,23 @@
+resource "aws_iam_user" "admin" {
+  for_each = toset(var.iam_admin_users)
+  name     = each.value
+}
+
+resource "aws_iam_group" "admin" {
+  name = "admin"
+}
+
+data "aws_iam_policy" "admin" {
+  arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+resource "aws_iam_group_policy_attachment" "admin" {
+  group      = aws_iam_group.admin.name
+  policy_arn = data.aws_iam_policy.admin.arn
+}
+
+resource "aws_iam_group_membership" "admin" {
+  name  = "admin"
+  users = [for user in aws_iam_user.admin : user.name]
+  group = aws_iam_group.admin.name
+}

--- a/modules/infra/iam_users/variables.tf
+++ b/modules/infra/iam_users/variables.tf
@@ -1,0 +1,4 @@
+variable "iam_admin_users" {
+  type        = list(string)
+  description = "List of IAM admin users to be created."
+}


### PR DESCRIPTION
```console
$ tofu plan
module.iam_users.data.aws_iam_policy.admin: Reading...
module.iam_users.aws_iam_group.admin: Refreshing state... [id=admin]
module.iam_users.aws_iam_user.admin["Ian_Edington_Laptop"]: Refreshing state... [id=Ian_Edington_Laptop]
module.iam_users.aws_iam_user.admin["rsalmond"]: Refreshing state... [id=rsalmond]
module.iam_users.aws_iam_group_membership.admin: Refreshing state... [id=admin]
module.iam_users.data.aws_iam_policy.admin: Read complete after 1s [id=arn:aws:iam::aws:policy/AdministratorAccess]
module.iam_users.aws_iam_group_policy_attachment.admin: Refreshing state... [id=admin-20241220172934857800000001]

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```