### PR TITLE
pin providers to exact versions

### DIFF
--- a/app/prod/.terraform.lock.hcl
+++ b/app/prod/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.opentofu.org/carlpett/sops" {
   version     = "0.7.2"
-  constraints = "~> 0.5"
+  constraints = "0.7.2"
   hashes = [
     "h1:+A1/RJ3eNVQHDFHjol70EfC5Yh9e78WMXxh1uoxlAYQ=",
     "h1:3Bw0Dms7NNi0bgH9kdWcSapc9hBKQy9yFMwdxivR83c=",
@@ -21,7 +21,7 @@ provider "registry.opentofu.org/carlpett/sops" {
 
 provider "registry.opentofu.org/digitalocean/digitalocean" {
   version     = "2.46.1"
-  constraints = "~> 2.0"
+  constraints = "2.46.1"
   hashes = [
     "h1:/YBD/kv3WeII/+W8hAudSuaBmwJYiWcBUBFaNJB1z7Q=",
     "h1:0eaY0ZVyCf1BJHVES0qQz3Ctl3AM9ONm62j9hNRPsWw=",

--- a/app/prod/tofu.tf
+++ b/app/prod/tofu.tf
@@ -2,12 +2,12 @@ terraform {
   required_providers {
     digitalocean = {
       source  = "digitalocean/digitalocean"
-      version = "~> 2.0"
+      version = "2.46.1"
     }
 
     sops = {
       source  = "carlpett/sops"
-      version = "~> 0.5"
+      version = "0.7.2"
     }
   }
 

--- a/app/stage/.terraform.lock.hcl
+++ b/app/stage/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.opentofu.org/carlpett/sops" {
   version     = "0.7.2"
-  constraints = "~> 0.5"
+  constraints = "0.7.2"
   hashes = [
     "h1:+A1/RJ3eNVQHDFHjol70EfC5Yh9e78WMXxh1uoxlAYQ=",
     "h1:3Bw0Dms7NNi0bgH9kdWcSapc9hBKQy9yFMwdxivR83c=",
@@ -21,7 +21,7 @@ provider "registry.opentofu.org/carlpett/sops" {
 
 provider "registry.opentofu.org/digitalocean/digitalocean" {
   version     = "2.46.1"
-  constraints = "~> 2.0"
+  constraints = "2.46.1"
   hashes = [
     "h1:/YBD/kv3WeII/+W8hAudSuaBmwJYiWcBUBFaNJB1z7Q=",
     "h1:0eaY0ZVyCf1BJHVES0qQz3Ctl3AM9ONm62j9hNRPsWw=",

--- a/app/stage/tofu.tf
+++ b/app/stage/tofu.tf
@@ -2,12 +2,12 @@ terraform {
   required_providers {
     digitalocean = {
       source  = "digitalocean/digitalocean"
-      version = "~> 2.0"
+      version = "2.46.1"
     }
 
     sops = {
       source  = "carlpett/sops"
-      version = "~> 0.5"
+      version = "0.7.2"
     }
   }
 

--- a/bootstrap/.terraform.lock.hcl
+++ b/bootstrap/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.opentofu.org/hashicorp/aws" {
   version     = "5.81.0"
-  constraints = "~> 5.60"
+  constraints = "5.81.0"
   hashes = [
     "h1:7mo2SoOo277YMcE7wFScaaI1zkzao7OWu3mfEqWjL+8=",
     "h1:7u9iQx2dxJWCIYX/Gj4UxbsqiJht2iPFs/TZ+Qy3KXM=",

--- a/bootstrap/tofu.tf
+++ b/bootstrap/tofu.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.60"
+      version = "5.81"
     }
   }
 

--- a/infra/prod/.terraform.lock.hcl
+++ b/infra/prod/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.opentofu.org/carlpett/sops" {
   version     = "0.7.2"
-  constraints = "~> 0.5"
+  constraints = "0.7.2"
   hashes = [
     "h1:+A1/RJ3eNVQHDFHjol70EfC5Yh9e78WMXxh1uoxlAYQ=",
     "h1:3Bw0Dms7NNi0bgH9kdWcSapc9hBKQy9yFMwdxivR83c=",
@@ -21,7 +21,7 @@ provider "registry.opentofu.org/carlpett/sops" {
 
 provider "registry.opentofu.org/digitalocean/digitalocean" {
   version     = "2.46.1"
-  constraints = "~> 2.0"
+  constraints = "2.46.1"
   hashes = [
     "h1:/YBD/kv3WeII/+W8hAudSuaBmwJYiWcBUBFaNJB1z7Q=",
     "h1:0eaY0ZVyCf1BJHVES0qQz3Ctl3AM9ONm62j9hNRPsWw=",
@@ -48,7 +48,7 @@ provider "registry.opentofu.org/digitalocean/digitalocean" {
 
 provider "registry.opentofu.org/hashicorp/aws" {
   version     = "5.81.0"
-  constraints = "~> 5.60"
+  constraints = "5.81.0"
   hashes = [
     "h1:7mo2SoOo277YMcE7wFScaaI1zkzao7OWu3mfEqWjL+8=",
     "h1:7u9iQx2dxJWCIYX/Gj4UxbsqiJht2iPFs/TZ+Qy3KXM=",

--- a/infra/prod/tofu.tf
+++ b/infra/prod/tofu.tf
@@ -3,17 +3,17 @@ terraform {
 
     digitalocean = {
       source  = "digitalocean/digitalocean"
-      version = "~> 2.0"
+      version = "2.46.1"
     }
 
     sops = {
       source  = "carlpett/sops"
-      version = "~> 0.5"
+      version = "0.7.2"
     }
 
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.60"
+      version = "5.81"
     }
   }
 

--- a/infra/singletons/.terraform.lock.hcl
+++ b/infra/singletons/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.opentofu.org/carlpett/sops" {
   version     = "0.7.2"
-  constraints = "~> 0.5"
+  constraints = "0.7.2"
   hashes = [
     "h1:+A1/RJ3eNVQHDFHjol70EfC5Yh9e78WMXxh1uoxlAYQ=",
     "h1:3Bw0Dms7NNi0bgH9kdWcSapc9hBKQy9yFMwdxivR83c=",
@@ -21,7 +21,7 @@ provider "registry.opentofu.org/carlpett/sops" {
 
 provider "registry.opentofu.org/cloudflare/cloudflare" {
   version     = "4.48.0"
-  constraints = "~> 4.0"
+  constraints = "4.48.0"
   hashes = [
     "h1:SX42e3k73IcFcrQlZ2e/Veqt2tvCMy6fwlo5yNUktCE=",
     "h1:ePGvSurmlqOCkD761vkhRmz7bsK36/EnIvx2Xy8TdXo=",
@@ -47,7 +47,7 @@ provider "registry.opentofu.org/cloudflare/cloudflare" {
 
 provider "registry.opentofu.org/integrations/github" {
   version     = "6.4.0"
-  constraints = "~> 6.0"
+  constraints = "~> 6.0, 6.4.0"
   hashes = [
     "h1:3JNFM7w0c/R02ZfcqCctCnCIYFz8QZpDV3ZGcI3i2u8=",
     "h1:B1q5+Ub1G3zJa9y474Fg40eo/N04/vOSeaf3dWaCG0I=",

--- a/infra/singletons/tofu.tf
+++ b/infra/singletons/tofu.tf
@@ -3,17 +3,17 @@ terraform {
 
     sops = {
       source  = "carlpett/sops"
-      version = "~> 0.5"
+      version = "0.7.2"
     }
 
     github = {
       source  = "integrations/github"
-      version = "~> 6.0"
+      version = "6.4.0"
     }
 
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 4.0"
+      version = "4.48.0"
     }
   }
 

--- a/infra/stage/.terraform.lock.hcl
+++ b/infra/stage/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.opentofu.org/carlpett/sops" {
   version     = "0.7.2"
-  constraints = "~> 0.5"
+  constraints = "0.7.2"
   hashes = [
     "h1:+A1/RJ3eNVQHDFHjol70EfC5Yh9e78WMXxh1uoxlAYQ=",
     "h1:3Bw0Dms7NNi0bgH9kdWcSapc9hBKQy9yFMwdxivR83c=",
@@ -21,7 +21,7 @@ provider "registry.opentofu.org/carlpett/sops" {
 
 provider "registry.opentofu.org/digitalocean/digitalocean" {
   version     = "2.46.1"
-  constraints = "~> 2.0"
+  constraints = "2.46.1"
   hashes = [
     "h1:/YBD/kv3WeII/+W8hAudSuaBmwJYiWcBUBFaNJB1z7Q=",
     "h1:0eaY0ZVyCf1BJHVES0qQz3Ctl3AM9ONm62j9hNRPsWw=",
@@ -48,7 +48,7 @@ provider "registry.opentofu.org/digitalocean/digitalocean" {
 
 provider "registry.opentofu.org/hashicorp/aws" {
   version     = "5.81.0"
-  constraints = "~> 5.60"
+  constraints = "5.81.0"
   hashes = [
     "h1:7mo2SoOo277YMcE7wFScaaI1zkzao7OWu3mfEqWjL+8=",
     "h1:7u9iQx2dxJWCIYX/Gj4UxbsqiJht2iPFs/TZ+Qy3KXM=",

--- a/infra/stage/tofu.tf
+++ b/infra/stage/tofu.tf
@@ -3,17 +3,17 @@ terraform {
 
     digitalocean = {
       source  = "digitalocean/digitalocean"
-      version = "~> 2.0"
+      version = "2.46.1"
     }
 
     sops = {
       source  = "carlpett/sops"
-      version = "~> 0.5"
+      version = "0.7.2"
     }
 
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.60"
+      version = "5.81"
     }
   }
 


### PR DESCRIPTION
Pinning our provider versions prevents unexpected changes to infra / checksums files.