### PR TITLE
How should we share secrets

### DIFF
--- a/DECISION_LOG.md
+++ b/DECISION_LOG.md
@@ -37,3 +37,11 @@ One case where using TF to put stuff into K8s is useful is configuration / secre
 Terraform is good at managing static infrastructure, it's not as good at managing constantly changing infrastructure like inside Kubernetes. We'll use Kubernetes yml or similar to manage Kubernetes.
 
 Decision: Generally NO, but not a strict ban.
+
+### 2024-12 How should we share secrets?
+
+We landed on sops because it's simple and we know it:
+- https://github.com/gpo/gpo-platform-configs/issues/30
+- https://github.com/gpo/gpo-platform-configs/pull/31
+
+Should we revisit this decision?


### PR DESCRIPTION
Pulled from #69

I figured we could pull the discussion about sops out of the PR since it's not blocking this specific PR.

from @azend:

I just want to take a moment to think about sops. I really like sops. But sops has some limitations like being local to the repository that make it not always the best tool for the job. It's not a concern of security but it can be and often is an issue with packaging. If we're investing in an AWS environment, parameter store is free, requires no additional KMS keys which have a small monthly cost, and are setup to be shared between various services in the environment. Either can work and work well but I would personally take parameter store over sops any day unless there was a reason that justified the additional effort.