### PR TITLE
How should we store credentials for accessing aws?

### DIFF
--- a/DECISION_LOG.md
+++ b/DECISION_LOG.md
@@ -37,3 +37,7 @@ One case where using TF to put stuff into K8s is useful is configuration / secre
 Terraform is good at managing static infrastructure, it's not as good at managing constantly changing infrastructure like inside Kubernetes. We'll use Kubernetes yml or similar to manage Kubernetes.
 
 Decision: Generally NO, but not a strict ban.
+
+### 2024-12-11 How should we store credentials for accessing aws?
+
+from @rsalmond: I strongly recommend we all create an aws profile called gpo instead of exporting env vars so we can reference them in tooling (see line 4 of sops.yaml. Later when we have stage / prod isolation, our tooling cannot accidentally talk to the wrong environment by someone exporting the wrong env vars.


### PR DESCRIPTION
I think we can pull this conversation out of PR #69 too. 

Current thinking:
from @rsalmond: I strongly recommend we all create an [aws profile](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html#cli-configure-files-format) called gpo instead of exporting env vars so we can reference them in tooling (see line 4 of sops.yaml. Later when we have stage / prod isolation, our tooling cannot accidentally talk to the wrong environment by someone exporting the wrong env vars.

From @azend 
I'm not a big fan personally of setting profile names in Terraform. It requires that every project maintainer has an almost identical ~/.aws config which is rarely the case and almost never documented. I generally prefer pulling credentials from environment variables where there's no profile names to mix up. But you still maintain a similar level of security because any profile in your config still can't access a state bucket in another account. If there's really any concern down the line, we can implement a break glass mechanism for production changes as well. I imagine we have a Cloudtrail getting recorded as well.

Should we revisit the decision on how to store