### PR TITLE
add an ECR for the donor history report, grant eks users push access

### DIFF
--- a/infra/stage/locals.tf
+++ b/infra/stage/locals.tf
@@ -1,7 +1,10 @@
 locals {
-  project_name           = "gpo"
-  environment            = "stage"
+  project_name = "gpo"
+  environment  = "stage"
+  /* eks specific */
   nodegroup_desired_size = 1
   nodegroup_max_size     = 5
   nodegroup_min_size     = 1
+  /* ecr specific */
+  repositories = ["donor-history-report"]
 }

--- a/infra/stage/main.tf
+++ b/infra/stage/main.tf
@@ -17,3 +17,8 @@ module "eks" {
   nodegroup_min_size          = local.nodegroup_min_size
   nodegroup_max_size          = local.nodegroup_max_size
 }
+
+module "ecr" {
+  source       = "../../modules/infra/ecr"
+  repositories = local.repositories
+}

--- a/modules/bootstrap/iam_users/eks_users.tf
+++ b/modules/bootstrap/iam_users/eks_users.tf
@@ -34,6 +34,19 @@ resource "aws_iam_group_policy_attachment" "ro" {
   policy_arn = data.aws_iam_policy.ro.arn
 }
 
+
+########################################
+# allow users to push to ECR repositories
+
+data "aws_iam_policy" "ecr_power_user" {
+  arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
+}
+
+resource "aws_iam_group_policy_attachment" "ecr_power_user" {
+  group      = aws_iam_group.eks.name
+  policy_arn = data.aws_iam_policy.ecr_power_user.arn
+}
+
 ########################################
 # allow users to manage their own accounts
 

--- a/modules/infra/ecr/main.tf
+++ b/modules/infra/ecr/main.tf
@@ -1,0 +1,25 @@
+resource "aws_ecr_repository" "main" {
+  for_each = toset(var.repositories)
+  name     = "gpo/${each.value}"
+}
+
+resource "aws_ecr_lifecycle_policy" "main" {
+  for_each   = aws_ecr_repository.main
+  repository = each.value.name
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1,
+        description  = "Keep last 30 images",
+        selection = {
+          tagStatus   = "any", // count both tagged and untagged images
+          countType   = "imageCountMoreThan",
+          countNumber = 30
+        },
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/modules/infra/ecr/variables.tf
+++ b/modules/infra/ecr/variables.tf
@@ -1,0 +1,4 @@
+variable "repositories" {
+  type        = list(string)
+  description = "List of repository names to create in our registry."
+}


### PR DESCRIPTION
This adds a container registry with a repository for the contribution history job, and grants non-admin IAM users push access to it.