### PR TITLE
Iam user kms decrypt

### DIFF
--- a/bootstrap/prod/main.tf
+++ b/bootstrap/prod/main.tf
@@ -2,6 +2,7 @@ module "iam_users" {
   source          = "../../modules/bootstrap/iam_users"
   iam_admin_users = local.iam_admin_users
   iam_eks_users   = local.iam_eks_users
+  environment     = local.environment
 }
 
 module "state_bucket" {

--- a/bootstrap/stage/main.tf
+++ b/bootstrap/stage/main.tf
@@ -2,6 +2,7 @@ module "iam_users" {
   source          = "../../modules/bootstrap/iam_users"
   iam_admin_users = local.iam_admin_users
   iam_eks_users   = local.iam_eks_users
+  environment     = local.environment
 }
 
 module "state_bucket" {

--- a/modules/bootstrap/iam_users/data.tf
+++ b/modules/bootstrap/iam_users/data.tf
@@ -1,0 +1,3 @@
+# fetch details of the current account access
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity
+data "aws_caller_identity" "main" {}

--- a/modules/bootstrap/iam_users/eks_users.tf
+++ b/modules/bootstrap/iam_users/eks_users.tf
@@ -23,31 +23,6 @@ resource "aws_iam_group_membership" "eks" {
 }
 
 ########################################
-# allow users to see everything
-
-data "aws_iam_policy" "ro" {
-  arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
-}
-
-resource "aws_iam_group_policy_attachment" "ro" {
-  group      = aws_iam_group.eks.name
-  policy_arn = data.aws_iam_policy.ro.arn
-}
-
-
-########################################
-# allow users to push to ECR repositories
-
-data "aws_iam_policy" "ecr_power_user" {
-  arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
-}
-
-resource "aws_iam_group_policy_attachment" "ecr_power_user" {
-  group      = aws_iam_group.eks.name
-  policy_arn = data.aws_iam_policy.ecr_power_user.arn
-}
-
-########################################
 # allow users to manage their own accounts
 
 data "aws_iam_policy_document" "manage_own_access" {

--- a/modules/bootstrap/iam_users/eks_users_stage.tf
+++ b/modules/bootstrap/iam_users/eks_users_stage.tf
@@ -1,0 +1,54 @@
+###############################################
+# allow users to see everything if env == stage
+
+data "aws_iam_policy" "ro" {
+  count = local.grant_stage_access ? 1 : 0
+  arn   = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+resource "aws_iam_group_policy_attachment" "ro" {
+  count      = local.grant_stage_access ? 1 : 0
+  group      = aws_iam_group.eks.name
+  policy_arn = data.aws_iam_policy.ro[0].arn
+}
+
+###############################################
+# allow users to push to ECR repositories if env == stage
+
+data "aws_iam_policy" "ecr_power_user" {
+  count = local.grant_stage_access ? 1 : 0
+  arn   = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
+}
+
+resource "aws_iam_group_policy_attachment" "ecr_power_user" {
+  count      = local.grant_stage_access ? 1 : 0
+  group      = aws_iam_group.eks.name
+  policy_arn = data.aws_iam_policy.ecr_power_user[0].arn
+}
+
+###############################################
+# allow users to perform KMS decryption with any key if env == stage
+
+data "aws_iam_policy_document" "kms_decrypt" {
+  count = local.grant_stage_access ? 1 : 0
+  statement {
+    sid = "AllowKMSDecrypt"
+    actions = [
+      "kms:Decrypt"
+    ]
+    effect    = "Allow"
+    resources = ["arn:aws:kms::${data.aws_caller_identity.main.account_id}:key/*"]
+  }
+}
+
+resource "aws_iam_policy" "kms_decrypt" {
+  count       = local.grant_stage_access ? 1 : 0
+  description = "Allow IAM users to perform KMS decryption with any key."
+  policy      = data.aws_iam_policy_document.kms_decrypt[0].json
+}
+
+resource "aws_iam_group_policy_attachment" "kms_decrypt" {
+  count      = local.grant_stage_access ? 1 : 0
+  group      = aws_iam_group.eks.name
+  policy_arn = aws_iam_policy.kms_decrypt[0].arn
+}

--- a/modules/bootstrap/iam_users/locals.tf
+++ b/modules/bootstrap/iam_users/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  grant_stage_access = lower(var.environment) == "stage"
+}

--- a/modules/bootstrap/iam_users/variables.tf
+++ b/modules/bootstrap/iam_users/variables.tf
@@ -7,3 +7,8 @@ variable "iam_eks_users" {
   type        = list(string)
   description = "List of IAM eks users to be created."
 }
+
+variable "environment" {
+  type        = string
+  description = "One of 'prod' or 'stage'."
+}

--- a/modules/infra/vpc/outputs.tf
+++ b/modules/infra/vpc/outputs.tf
@@ -13,3 +13,8 @@ output "private_active_subnet_id" {
 output "private_inactive_subnet_id" {
   value = aws_subnet.private_inactive.id
 }
+
+output "nat_gateway_public_ip" {
+  value       = aws_nat_gateway.main.public_ip
+  description = "Source IP address of traffic leaving the cluster."
+}


### PR DESCRIPTION
This change adds our first branching logic which I don't love, but it's either this or have a completely separate module for stage access (which honestly I could get behind, but this is simpler). This also opens up a path for us to be very decisive about what ppl can do in stage vs prod. (Eg. we could trivially give devs power user access to stage and RO to prod etc.)

Right now when `env == stage` we grant IAM users in the `eks` group read only access to everything and the ability to perform KMS decryption. This has been applied in staging, holding PR in draft until we can confirm this works as expected (see gpo/gpo#25)