### PR TITLE
Bring GCP Projects under TF control

### DIFF
--- a/bootstrap/prod/.terraform.lock.hcl
+++ b/bootstrap/prod/.terraform.lock.hcl
@@ -21,3 +21,24 @@ provider "registry.opentofu.org/hashicorp/aws" {
     "zh:e76cd202b03749f3082b0cbe849fd2e731cf3f9a6aa994d2d629602c3aede36c",
   ]
 }
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.8.0"
+  constraints = "6.8.0"
+  hashes = [
+    "h1:7kVqtv9WITz2SMZKk+6nFjFEUvur/DTR3u29D8y6IWc=",
+    "h1:ZAZmM/vklsAEjpXZkR4sPzSCSiGkAPVXrxZ/aXYwXVM=",
+    "h1:iNrCvileo2XwA4RJoIFbXCCwLt4BPefbwATjQkINMvw=",
+    "h1:lGhTjjKozpr3ZX3zipw3DJOAhNw7mAGQyWrmJJKkMFg=",
+    "zh:06a80f46f4f49d30c7cdb07f5d0715b8398497f1d86acda43b32817cb99c0cfd",
+    "zh:073b406305aa675e8b367224485270ed1f18de86cc7afdaa202bbd8562dc32a7",
+    "zh:11c2e9f0de6eda72a4ba646a25cceeb489cfe7a39c26f48ff20421b3289b8fa7",
+    "zh:39d0db53e543d50eb267c56a6461039db4b08d0c99fbe5cd5b9beb3d0efe296e",
+    "zh:4bbbbaf241eb91fc7ba575c6b85706299c7a42b700dc74fd12dfa9f93d3c0102",
+    "zh:582332cf741c265f5e72cb35984598b7130aaf5580b243b5529fda30bdf12129",
+    "zh:881dc8c132273991941b018f8012a977b4a7ebb32f0fb99c7b5f5757dfb96b06",
+    "zh:96d2258f074b237ef735023be038f818f3ea975f4175e7598ac2b477d12df8f8",
+    "zh:b3cc4e99128a97ad640c12e7dc39299b52c4205f0201e53f9a674c0dfb623d49",
+    "zh:eaf2fc5acc3cba9c756da51295ad0e45d1f024f84490b920d989357c52c98562",
+  ]
+}

--- a/bootstrap/prod/gcp_projects.tf
+++ b/bootstrap/prod/gcp_projects.tf
@@ -1,0 +1,6 @@
+resource "google_project" "gpo_data" {
+  name            = "gpo-data-prod"
+  project_id      = "gpo-data-prod"
+  org_id          = local.gcp_org_id
+  billing_account = local.gcp_billing_account
+}

--- a/bootstrap/prod/locals.tf
+++ b/bootstrap/prod/locals.tf
@@ -1,5 +1,7 @@
 locals {
-  iam_admin_users = ["rsalmond", "ianedington"]
-  iam_eks_users   = []
-  environment     = "prod"
+  iam_admin_users     = ["rsalmond", "ianedington"]
+  iam_eks_users       = []
+  environment         = "prod"
+  gcp_org_id          = 267619224561
+  gcp_billing_account = "019C4D-E56387-A59CAF"
 }

--- a/bootstrap/prod/outputs.tf
+++ b/bootstrap/prod/outputs.tf
@@ -13,3 +13,11 @@ output "user_creds" {
   sensitive   = true
   description = "Map of usernames to temporary initial passwords (must be changed on first login)."
 }
+
+output "gcp_project_gpo_data" {
+  value = {
+    project_id = google_project.gpo_data.project_id
+    name       = google_project.gpo_data.name
+  }
+  description = "Project name and project ID for the GPO Data project"
+}

--- a/bootstrap/prod/tofu.tf
+++ b/bootstrap/prod/tofu.tf
@@ -4,6 +4,11 @@ terraform {
       source  = "hashicorp/aws"
       version = "5.81"
     }
+
+    google = {
+      source  = "hashicorp/google"
+      version = "6.8.0"
+    }
   }
 
   backend "s3" {

--- a/bootstrap/stage/.terraform.lock.hcl
+++ b/bootstrap/stage/.terraform.lock.hcl
@@ -21,3 +21,24 @@ provider "registry.opentofu.org/hashicorp/aws" {
     "zh:e76cd202b03749f3082b0cbe849fd2e731cf3f9a6aa994d2d629602c3aede36c",
   ]
 }
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.8.0"
+  constraints = "6.8.0"
+  hashes = [
+    "h1:7kVqtv9WITz2SMZKk+6nFjFEUvur/DTR3u29D8y6IWc=",
+    "h1:ZAZmM/vklsAEjpXZkR4sPzSCSiGkAPVXrxZ/aXYwXVM=",
+    "h1:iNrCvileo2XwA4RJoIFbXCCwLt4BPefbwATjQkINMvw=",
+    "h1:lGhTjjKozpr3ZX3zipw3DJOAhNw7mAGQyWrmJJKkMFg=",
+    "zh:06a80f46f4f49d30c7cdb07f5d0715b8398497f1d86acda43b32817cb99c0cfd",
+    "zh:073b406305aa675e8b367224485270ed1f18de86cc7afdaa202bbd8562dc32a7",
+    "zh:11c2e9f0de6eda72a4ba646a25cceeb489cfe7a39c26f48ff20421b3289b8fa7",
+    "zh:39d0db53e543d50eb267c56a6461039db4b08d0c99fbe5cd5b9beb3d0efe296e",
+    "zh:4bbbbaf241eb91fc7ba575c6b85706299c7a42b700dc74fd12dfa9f93d3c0102",
+    "zh:582332cf741c265f5e72cb35984598b7130aaf5580b243b5529fda30bdf12129",
+    "zh:881dc8c132273991941b018f8012a977b4a7ebb32f0fb99c7b5f5757dfb96b06",
+    "zh:96d2258f074b237ef735023be038f818f3ea975f4175e7598ac2b477d12df8f8",
+    "zh:b3cc4e99128a97ad640c12e7dc39299b52c4205f0201e53f9a674c0dfb623d49",
+    "zh:eaf2fc5acc3cba9c756da51295ad0e45d1f024f84490b920d989357c52c98562",
+  ]
+}

--- a/bootstrap/stage/gcp_projects.tf
+++ b/bootstrap/stage/gcp_projects.tf
@@ -1,0 +1,6 @@
+resource "google_project" "gpo_data" {
+  name            = "gpo-data-stage"
+  project_id      = "calm-segment-466901-e4"
+  org_id          = local.gcp_org_id
+  billing_account = local.gcp_billing_account
+}

--- a/bootstrap/stage/locals.tf
+++ b/bootstrap/stage/locals.tf
@@ -1,5 +1,7 @@
 locals {
-  iam_admin_users = ["rsalmond", "ianedington", "verdird", "mattw"]
-  iam_eks_users   = ["pnovikov"]
-  environment     = "stage"
+  iam_admin_users     = ["rsalmond", "ianedington", "verdird", "mattw"]
+  iam_eks_users       = ["pnovikov"]
+  environment         = "stage"
+  gcp_org_id          = 267619224561
+  gcp_billing_account = "019C4D-E56387-A59CAF"
 }

--- a/bootstrap/stage/outputs.tf
+++ b/bootstrap/stage/outputs.tf
@@ -13,3 +13,11 @@ output "user_creds" {
   sensitive   = true
   description = "Map of usernames to temporary initial passwords (must be changed on first login)."
 }
+
+output "gcp_project_gpo_data" {
+  value = {
+    project_id = google_project.gpo_data.project_id
+    name       = google_project.gpo_data.name
+  }
+  description = "Project name and project ID for the GPO Data project"
+}

--- a/bootstrap/stage/tofu.tf
+++ b/bootstrap/stage/tofu.tf
@@ -4,6 +4,11 @@ terraform {
       source  = "hashicorp/aws"
       version = "5.81"
     }
+
+    google = {
+      source  = "hashicorp/google"
+      version = "6.8.0"
+    }
   }
 
   backend "s3" {


### PR DESCRIPTION
This change captures the existing GCP projects in TF. All resources have been `terraform import`ed into current state files.

Note that this violates the "no resources - only modules" tenet of our TF layout by putting `google_project` resources directly into `bootstrap/prod` and `bootstrap/stage`. I opted to do this for the sake of simplicity. 

1. We need these projects to exist _before_ we create resources within them in (eg. in `infra/stage` TF), bootstrap seemed the sensible place for this.
2. Creating a reusable module for a single resource feels like it adds more in unwanted complexity than it buys us in  confidence about correctness of our TF (which is the primary argument for reusable modules).
3. We can hide the naming differences from other TF which will use these projects by referencing the `output` added in this PR. Since the new output has the same name in both prod and stage, any TF that consumes it doesn't need to know which project its in. It just needs to be constrained to using a particular TF state (which they all are anyway).