### PR TITLE
add GKE support

### DIFF
--- a/bootstrap/prod/gcp_projects.tf
+++ b/bootstrap/prod/gcp_projects.tf
@@ -4,3 +4,10 @@ resource "google_project" "gpo_data" {
   org_id          = local.gcp_org_id
   billing_account = local.gcp_billing_account
 }
+
+resource "google_project" "gpo_eng" {
+  name            = "gpo-eng-prod"
+  project_id      = "gpo-eng-prod"
+  org_id          = local.gcp_org_id
+  billing_account = local.gcp_billing_account
+}

--- a/bootstrap/prod/outputs.tf
+++ b/bootstrap/prod/outputs.tf
@@ -21,3 +21,11 @@ output "gcp_project_gpo_data" {
   }
   description = "Project name and project ID for the GPO Data project"
 }
+
+output "gcp_project_gpo_eng" {
+  value = {
+    project_id = google_project.gpo_eng.project_id
+    name       = google_project.gpo_eng.name
+  }
+  description = "Project name and project ID for the GPO Eng project"
+}

--- a/bootstrap/stage/gcp_projects.tf
+++ b/bootstrap/stage/gcp_projects.tf
@@ -4,3 +4,10 @@ resource "google_project" "gpo_data" {
   org_id          = local.gcp_org_id
   billing_account = local.gcp_billing_account
 }
+
+resource "google_project" "gpo_eng" {
+  name            = "gpo-eng-stage"
+  project_id      = "gpo-eng-stage"
+  org_id          = local.gcp_org_id
+  billing_account = local.gcp_billing_account
+}

--- a/bootstrap/stage/outputs.tf
+++ b/bootstrap/stage/outputs.tf
@@ -21,3 +21,11 @@ output "gcp_project_gpo_data" {
   }
   description = "Project name and project ID for the GPO Data project"
 }
+
+output "gcp_project_gpo_eng" {
+  value = {
+    project_id = google_project.gpo_eng.project_id
+    name       = google_project.gpo_eng.name
+  }
+  description = "Project name and project ID for the GPO Eng project"
+}

--- a/infra/prod/.terraform.lock.hcl
+++ b/infra/prod/.terraform.lock.hcl
@@ -66,3 +66,24 @@ provider "registry.opentofu.org/hashicorp/aws" {
     "zh:e76cd202b03749f3082b0cbe849fd2e731cf3f9a6aa994d2d629602c3aede36c",
   ]
 }
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.8.0"
+  constraints = "6.8.0"
+  hashes = [
+    "h1:7kVqtv9WITz2SMZKk+6nFjFEUvur/DTR3u29D8y6IWc=",
+    "h1:ZAZmM/vklsAEjpXZkR4sPzSCSiGkAPVXrxZ/aXYwXVM=",
+    "h1:iNrCvileo2XwA4RJoIFbXCCwLt4BPefbwATjQkINMvw=",
+    "h1:lGhTjjKozpr3ZX3zipw3DJOAhNw7mAGQyWrmJJKkMFg=",
+    "zh:06a80f46f4f49d30c7cdb07f5d0715b8398497f1d86acda43b32817cb99c0cfd",
+    "zh:073b406305aa675e8b367224485270ed1f18de86cc7afdaa202bbd8562dc32a7",
+    "zh:11c2e9f0de6eda72a4ba646a25cceeb489cfe7a39c26f48ff20421b3289b8fa7",
+    "zh:39d0db53e543d50eb267c56a6461039db4b08d0c99fbe5cd5b9beb3d0efe296e",
+    "zh:4bbbbaf241eb91fc7ba575c6b85706299c7a42b700dc74fd12dfa9f93d3c0102",
+    "zh:582332cf741c265f5e72cb35984598b7130aaf5580b243b5529fda30bdf12129",
+    "zh:881dc8c132273991941b018f8012a977b4a7ebb32f0fb99c7b5f5757dfb96b06",
+    "zh:96d2258f074b237ef735023be038f818f3ea975f4175e7598ac2b477d12df8f8",
+    "zh:b3cc4e99128a97ad640c12e7dc39299b52c4205f0201e53f9a674c0dfb623d49",
+    "zh:eaf2fc5acc3cba9c756da51295ad0e45d1f024f84490b920d989357c52c98562",
+  ]
+}

--- a/infra/prod/locals.tf
+++ b/infra/prod/locals.tf
@@ -1,7 +1,7 @@
 locals {
-  project_name           = "gpo"
-  environment            = "prod"
-  nodegroup_desired_size = 2
-  nodegroup_max_size     = 16
-  nodegroup_min_size     = 2
+  name        = "gpo" # broadly used as a prefix for resource names
+  environment = "prod"
+  /* gcp specific */
+  region_toronto = "northamerica-northeast2"
+  zone_toronto   = "northamerica-northeast2-a"
 }

--- a/infra/prod/main.tf
+++ b/infra/prod/main.tf
@@ -1,0 +1,9 @@
+module "gke" {
+  source      = "../../modules/infra/gcp/gke"
+  name        = local.name
+  environment = local.environment
+  location    = local.zone_toronto
+  providers = {
+    google = google.gpo_eng
+  }
+}

--- a/infra/prod/tofu.tf
+++ b/infra/prod/tofu.tf
@@ -15,6 +15,11 @@ terraform {
       source  = "hashicorp/aws"
       version = "5.81"
     }
+
+    google = {
+      source  = "hashicorp/google"
+      version = "6.8.0"
+    }
   }
 
   backend "s3" {
@@ -34,4 +39,9 @@ provider "aws" {
 
 provider "digitalocean" {
   token = data.sops_file.secrets.data["do_token"]
+}
+
+provider "google" {
+  project = data.terraform_remote_state.bootstrap.outputs.gcp_project_gpo_eng.project_id
+  alias   = "gpo_eng"
 }

--- a/infra/stage/locals.tf
+++ b/infra/stage/locals.tf
@@ -1,10 +1,7 @@
 locals {
-  project_name = "gpo"
-  environment  = "stage"
-  /* eks specific */
-  nodegroup_desired_size = 1
-  nodegroup_max_size     = 5
-  nodegroup_min_size     = 1
-  /* ecr specific */
-  repositories = ["gpo-monolith"]
+  name        = "gpo" # broadly used as a prefix for resource names
+  environment = "stage"
+  /* gcp specific */
+  region_toronto = "northamerica-northeast2"
+  zone_toronto   = "northamerica-northeast2-a"
 }

--- a/infra/stage/main.tf
+++ b/infra/stage/main.tf
@@ -1,25 +1,9 @@
-/* decom EKS for now
-module "vpc" {
-  source      = "../../modules/infra/vpc"
-  name        = local.project_name
+module "gke" {
+  source      = "../../modules/infra/gcp/gke"
+  name        = local.name
   environment = local.environment
+  location    = local.zone_toronto
+  providers = {
+    google = google.gpo_eng
+  }
 }
-
-module "eks" {
-  source                      = "../../modules/infra/eks"
-  name                        = local.project_name
-  environment                 = local.environment
-  public_subnet_ids           = [module.vpc.public_subnet_id]
-  private_active_subnet_ids   = [module.vpc.private_active_subnet_id]
-  private_inactive_subnet_ids = [module.vpc.private_inactive_subnet_id]
-  admin_user_arns             = data.terraform_remote_state.bootstrap.outputs.admin_user_arns
-  eks_user_arns               = data.terraform_remote_state.bootstrap.outputs.eks_user_arns
-  nodegroup_desired_size      = local.nodegroup_desired_size
-  nodegroup_min_size          = local.nodegroup_min_size
-  nodegroup_max_size          = local.nodegroup_max_size
-}
-
-module "ecr" {
-  source       = "../../modules/infra/ecr"
-  repositories = local.repositories
-} /decom */

--- a/infra/stage/tofu.tf
+++ b/infra/stage/tofu.tf
@@ -40,3 +40,8 @@ provider "aws" {
 provider "digitalocean" {
   token = data.sops_file.secrets.data["do_token"]
 }
+
+provider "google" {
+  project = data.terraform_remote_state.bootstrap.outputs.gcp_project_gpo_eng.project_id
+  alias   = "gpo_eng"
+}

--- a/modules/infra/gcp/gke/apis.tf
+++ b/modules/infra/gcp/gke/apis.tf
@@ -1,0 +1,9 @@
+resource "google_project_service" "compute" {
+  service            = "compute.googleapis.com"
+  disable_on_destroy = false # don't disable / renable the API on every tf destroy / apply
+}
+
+resource "google_project_service" "container" {
+  service            = "container.googleapis.com"
+  disable_on_destroy = false
+}

--- a/modules/infra/gcp/gke/main.tf
+++ b/modules/infra/gcp/gke/main.tf
@@ -1,0 +1,30 @@
+resource "google_compute_network" "main" {
+  depends_on              = [google_project_service.compute]
+  name                    = "${var.name}-${var.environment}"
+  auto_create_subnetworks = true
+}
+
+resource "google_service_account" "main" {
+  account_id   = "gke-${var.name}-${var.environment}"
+  display_name = "GKE ${var.name} ${var.environment}"
+}
+
+resource "google_container_cluster" "main" {
+  depends_on = [
+    google_project_service.compute,
+    google_project_service.container,
+  ]
+  deletion_protection = false
+  name                = "${var.name}-${var.environment}"
+  location            = var.location
+  initial_node_count  = 3
+
+  network = google_compute_network.main.name
+
+  node_config {
+    service_account = google_service_account.main.email
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+  }
+}

--- a/modules/infra/gcp/gke/tofu.tf
+++ b/modules/infra/gcp/gke/tofu.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}

--- a/modules/infra/gcp/gke/variables.tf
+++ b/modules/infra/gcp/gke/variables.tf
@@ -1,0 +1,17 @@
+variable "name" {
+  type        = string
+  description = "A base name for VPC resources."
+}
+
+variable "environment" {
+  type = string
+  validation {
+    condition     = contains(["prod", "stage"], var.environment)
+    error_message = "Must be one of 'stage' or 'prod'."
+  }
+}
+
+variable "location" {
+  type        = string
+  description = "Geographical location for the cluster."
+}


### PR DESCRIPTION
This change adds:

* TF control of GCP projects to contain clusters (these existing projects have been tf imported)
* uniformly named outputs from the `bootstrap` state which can be consumed by other TF states (so we don't have to hard-code project names inside of `infra/stage`, `infra/prod`, etc.
* a module which creates a GKE cluster.
  *  Note: this is simpler than the AWS modules as there are fewer moving parts in GCP, so instead of a separate VPC and cluster module we just have one compact module that does each of those things. Happy to revisit this organization choice in the future.

When it comes time to stand up a prod cluster, we'll probably want to add some knobs to allow control of node counts (ie. we probably want fewer nodes in stage than we do in prod) and similar things. Let's wait to see how much we use in stage before adding those things.

Note that this config does not use [GKE autopilot](https://cloud.google.com/kubernetes-engine/docs/resources/autopilot-standard-feature-comparison) which provides some extra operational management features (less for us to manage ourselves) but requires a multi-region cluster which is more expensive.  This current config is single zone aka "zonal".

This has been applied in stage and crews for the cluster can be obtained by running:

`gcloud container clusters get-credentials gpo-stage --zone northamerica-northeast2-a`