### PR TITLE
add a script to kill long running mysql queries made by our BI user

### DIFF
--- a/legacy/scripts/kill_long_queries.sh
+++ b/legacy/scripts/kill_long_queries.sh
@@ -27,7 +27,7 @@ LONG_QUERY_COUNT=$(mysql --login-path=${MYLOGIN_PATH} --skip-column-names --sile
 if [[ "${LONG_QUERY_COUNT}" -gt 0 ]]; then
 	log "${LONG_QUERY_COUNT} long running queries by 'big_query_user' found, killing them now..."
 else
-	log "No long running queries found, exiting."
+	# No long running queries found, nothing to do.
 	exit 0
 fi
 


### PR DESCRIPTION
This is currently running every minute on stage1. It will:
- look for MySQL queries made by our BI user which have been running for longer than 30 seconds
- kill them
- log what it's doing