### PR TITLE
grant GKE cluster access to read from our artifact registry

### DIFF
--- a/modules/infra/gcp/gke/data.tf
+++ b/modules/infra/gcp/gke/data.tf
@@ -1,0 +1,2 @@
+/* this is just a convenient way to look up the current GCP project */
+data "google_client_config" "current" {}

--- a/modules/infra/gcp/gke/iam.tf
+++ b/modules/infra/gcp/gke/iam.tf
@@ -1,0 +1,5 @@
+resource "google_project_iam_member" "main" {
+  project = data.google_client_config.current.project
+  role    = "roles/artifactregistry.reader"
+  member  = google_service_account.main.member
+}


### PR DESCRIPTION
This change gives the service account used by our GKE cluster read-only access to our docker registry (see #107)