### PR TITLE
tf pre-commit - allow upgrades & validate first

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,12 @@ repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: "v1.92.1"
     hooks:
+      - id: terraform_validate
+        args:
+        - --hook-config=--tf-path=tofu
+        - --hook-config=--retry-once-with-cleanup=true
+        - --tf-init-args=-upgrade
+        exclude: modules/.*$
       - id: terraform_providers_lock
         args:
         - --hook-config=--tf-path=tofu
@@ -26,8 +32,3 @@ repos:
       - id: terraform_fmt
         args:
         - --hook-config=--tf-path=tofu
-      - id: terraform_validate
-        args:
-        - --hook-config=--tf-path=tofu
-        - --hook-config=--retry-once-with-cleanup=true
-        exclude: modules/.*$


### PR DESCRIPTION
This change adds `tf-init-args=-upgrade` which allows our pre-commit hooks to automatically upgrade our TF providers when we bump version in `tofu.tf`. Without this, pre commit complains that we need to run `tf init -upgrade` in each tf state.

As noted by point 4 in [the docs](https://github.com/antonbabenko/pre-commit-terraform?tab=readme-ov-file#terraform_providers_lock) - if we leverage this feature of tf_validate it needs to execute _before_ the tf_providers_lock step happens.

<img width="858" height="261" alt="image" src="https://github.com/user-attachments/assets/36cd146f-1508-4793-bfc7-f09bee595166" />
