### PR TITLE
grant devs access to stage env

### DIFF
--- a/bootstrap/stage/locals.tf
+++ b/bootstrap/stage/locals.tf
@@ -1,7 +1,10 @@
 locals {
+  # users in these lists are granted AWS access (pending retirement of all AWS stuff)
   iam_admin_users     = ["rsalmond", "ianedington", "verdird", "mattw"]
   iam_eks_users       = ["pnovikov"]
   environment         = "stage"
   gcp_org_id          = 267619224561
   gcp_billing_account = "019C4D-E56387-A59CAF"
+  # every user in this list will be granted dev access
+  dev_users = ["tdresser@gmail.com"]
 }

--- a/bootstrap/stage/main.tf
+++ b/bootstrap/stage/main.tf
@@ -17,3 +17,10 @@ module "sops" {
     google = google.bootstrap
   }
 }
+
+module "gcp_iam_devs" {
+  for_each = toset(local.dev_users)
+  source   = "../../modules/bootstrap/gcp_iam_devs_stage"
+  project  = google_project.gpo_eng.project_id
+  user     = each.value
+}

--- a/modules/bootstrap/gcp_iam_devs_stage/main.tf
+++ b/modules/bootstrap/gcp_iam_devs_stage/main.tf
@@ -1,0 +1,13 @@
+# so they can push docker images
+resource "google_project_iam_member" "registry_writer" {
+  project = var.project
+  role    = "roles/artifactregistry.writer"
+  member  = "user:${var.user}"
+}
+
+# so they can use existing clusters but not delete / create them
+resource "google_project_iam_member" "gke_dev" {
+  project = var.project
+  role    = "roles/container.developer"
+  member  = "user:${var.user}"
+}

--- a/modules/bootstrap/gcp_iam_devs_stage/variables.tf
+++ b/modules/bootstrap/gcp_iam_devs_stage/variables.tf
@@ -1,0 +1,9 @@
+variable "project" {
+  type        = string
+  description = "GCP project in which to create the membership"
+}
+
+variable "user" {
+  type        = string
+  description = "User to give the membership to."
+}


### PR DESCRIPTION
While it seems a bit redundant to create a reusable module never be used outside of our stage environment this means:
 - we do NOT have funky data structures or fancy loops to generate all permutations of users x perms
 - we DO get the benefit of just adding a username to a list and not worrying that we accidentally forgot to grant them something