### PR TITLE
Add CLAUDE.md and feature-based agent documentation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,6 @@
   "rules": [
     "Never write plaintext secrets to any file. All secrets are SOPS-encrypted. Source files are secrets.env, secrets.prod.env, and secrets.stage.env at the repo root.",
     "tf/infra/singletons/ is global and has no staging equivalent. Changes apply to live production immediately — always plan carefully before applying.",
-    "Do not manage Kubernetes resources in Terraform. K8s manifests live in a separate repo. Terraform only manages cloud-provider resources."
+    "Kubernetes manifests live in /kubernetes. Terraform lives in /tf. Keep them separate — do not add K8s resources to /tf or Terraform resources to /kubernetes."
   ]
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "rules": [
+    "Always use -parallelism=1 when running tofu apply in any tf/app/ stack. GCP rate-limits concurrent API calls and applies will fail without it.",
+    "Never write plaintext secrets to any file. All secrets are SOPS-encrypted. Source files are secrets.env, secrets.prod.env, and secrets.stage.env at the repo root.",
+    "tf/infra/singletons/ is global and has no staging equivalent. Changes apply to live production immediately — always plan carefully before applying.",
+    "Do not manage Kubernetes resources in Terraform. K8s manifests live in a separate repo. Terraform only manages cloud-provider resources."
+  ]
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,5 @@
 {
   "rules": [
-    "Always use -parallelism=1 when running tofu apply in any tf/app/ stack. GCP rate-limits concurrent API calls and applies will fail without it.",
     "Never write plaintext secrets to any file. All secrets are SOPS-encrypted. Source files are secrets.env, secrets.prod.env, and secrets.stage.env at the repo root.",
     "tf/infra/singletons/ is global and has no staging equivalent. Changes apply to live production immediately — always plan carefully before applying.",
     "Do not manage Kubernetes resources in Terraform. K8s manifests live in a separate repo. Terraform only manages cloud-provider resources."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,15 +4,22 @@ Infrastructure as Code for GPO, managed with OpenTofu. Covers Cloudflare (DNS, P
 
 ## Stack layout
 
-```
-tf/
-├── bootstrap/{prod,stage}/        # One-time account setup
-├── infra/{singletons,prod,stage}/ # Clusters, zones, networks
-├── app/{prod,stage}/              # Per-app DNS, secrets, IAM
-└── modules/{app,infra,bootstrap}/ # Reusable modules — never deployed directly
+```mermaid
+graph LR
+    B[bootstrap\nprod · stage]
+    I[infra\nprod · stage]
+    S[infra/singletons\ngpo.ca · GitHub]
+    A[app\nprod · stage]
+    M[modules\napp · infra · bootstrap]
+
+    B -->|remote state| I
+    I -->|remote state| A
+    M -.->|used by| B & I & A
+
+    style S fill:#f5a623,color:#000
 ```
 
-`app` reads remote state from `infra`, which reads remote state from `bootstrap`. Singletons are independent and **global** — changes affect live production immediately.
+`singletons` is **global/production only** — no staging equivalent, changes are live immediately.
 
 ## Naming conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,111 @@
+# GPO Platform Configs — Agent Guide
+
+This repo is the single source of truth for GPO's infrastructure and platform configuration, managed with OpenTofu (Terraform-compatible).
+
+## What this repo manages
+
+- **Cloudflare** — DNS zones, records, Pages projects, redirect rules (gpo.ca, gpotools.ca, gpotoolsstage.ca)
+- **GitHub** — Repository creation, branch settings, issue labels, Actions secrets
+- **GCP / GKE** — Kubernetes clusters (Toronto), Artifact Registry, GCP projects, service accounts
+- **AWS / EKS** — EKS clusters, VPC networking, ECR, IAM users
+- **Secrets** — SOPS-encrypted secrets, KMS keys (AWS + GCP)
+- **Bootstrap** — One-time account setup (GCP projects, AWS IAM, S3 state buckets)
+
+---
+
+## Stack layout
+
+All Terraform lives under `tf/`. There are four independent stacks, each with its own state file:
+
+```
+tf/
+├── bootstrap/{prod,stage}/     # One-time account setup — run once, rarely touched
+├── infra/{singletons,prod,stage}/  # Clusters, zones, networks — shared infra
+├── app/{prod,stage}/           # Per-app resources — DNS, secrets, IAM bindings
+└── modules/                    # Reusable modules (never deployed directly)
+    ├── app/
+    ├── bootstrap/
+    └── infra/
+```
+
+Stacks are independent. `app` reads outputs from `infra` via `terraform_remote_state`. `infra` reads outputs from `bootstrap` the same way.
+
+**All state is stored in GCS bucket `gpo-tf-state-data`**, organised by path:
+
+| Stack | GCS prefix |
+|---|---|
+| bootstrap/prod | `prod/bootstrap` |
+| bootstrap/stage | `stage/bootstrap` |
+| infra/prod | `prod/infra` |
+| infra/stage | `stage/infra` |
+| infra/singletons | `infra/singletons` |
+| app/prod | `prod/app` |
+| app/stage | `stage/app` |
+
+---
+
+## Critical rules — read before touching anything
+
+1. **Never run `tofu apply` on `app/` with default parallelism.** GCP rate-limits concurrent API calls. Always use:
+   ```
+   tofu apply -parallelism=1
+   ```
+2. **Secrets are SOPS-encrypted.** Never commit plaintext secrets. Source files: `secrets.env` (shared), `secrets.prod.env`, `secrets.stage.env` in the repo root.
+3. **Two AWS CLI profiles are required:** `gpo-prod` (account 060795914812) and `gpo-stage` (account 542371827759), both `ca-central-1`.
+4. **Singletons are global** — changes to `tf/infra/singletons/` affect live production immediately (gpo.ca DNS, GitHub repos, etc.).
+5. **Don't put Kubernetes resources in Terraform** — K8s manifests live separately. TF manages cloud-provider resources only.
+
+---
+
+## Provider versions
+
+| Provider | Version used in `infra/` + singletons | Version used in `app/` |
+|---|---|---|
+| cloudflare/cloudflare | 4.48.0 | 5.15.0 |
+| integrations/github | 6.4.0 | — |
+| carlpett/sops | 0.7.2 | 0.7.2 |
+| hashicorp/aws | 5.81 | 5.81 |
+| hashicorp/google | 7.12.0 | 7.12.0 |
+| digitalocean/digitalocean | 2.46.1 | 2.46.1 |
+
+---
+
+## Naming conventions
+
+- Resource names: `snake_case`, qualified with environment where needed (e.g. `cloudflare_record.staging_gpo_ca`)
+- Module output objects for Cloudflare zones: `{ id = string, zone = string }`
+- DNS record `name` attribute: always the **full FQDN** (e.g. `"staging.gpo.ca"`, not `"staging"`)
+- TTL: always `1` when `proxied = true`, otherwise `300`
+- Toggle flags: use `locals {}` block, not `variable {}`, so no `-var` flags are needed at apply time
+
+---
+
+## How to apply changes
+
+```bash
+cd tf/<stack>/<environment>
+tofu init        # first time or after provider changes
+tofu plan
+tofu apply       # add -parallelism=1 for app/ stacks
+```
+
+To apply all stacks at once, use the `tofu-all` helper script in the repo root.
+
+---
+
+## Documentation index
+
+Read only the doc relevant to your task:
+
+| Task | Doc |
+|---|---|
+| Add or change DNS records / Cloudflare zones | [docs/cloudflare-dns.md](docs/cloudflare-dns.md) |
+| Deploy a Cloudflare Pages site | [docs/cloudflare-pages.md](docs/cloudflare-pages.md) |
+| Create or configure a GitHub repository | [docs/github-repos.md](docs/github-repos.md) |
+| Work with GKE, GCP projects, or Artifact Registry | [docs/gke-and-gcp.md](docs/gke-and-gcp.md) |
+| Work with EKS, VPC, or ECR | [docs/aws-eks.md](docs/aws-eks.md) |
+| Add or rotate secrets / SOPS | [docs/secrets-and-sops.md](docs/secrets-and-sops.md) |
+| Add an IAM user (AWS or GCP) | [docs/iam-users.md](docs/iam-users.md) |
+| Understand stack boundaries or remote state wiring | [docs/stacks-and-state.md](docs/stacks-and-state.md) |
+| Add a new application to the app layer | [docs/app-layer.md](docs/app-layer.md) |
+| Bootstrap a new cloud account | [docs/bootstrap.md](docs/bootstrap.md) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,111 +1,38 @@
-# GPO Platform Configs — Agent Guide
+# GPO Platform Configs
 
-This repo is the single source of truth for GPO's infrastructure and platform configuration, managed with OpenTofu (Terraform-compatible).
-
-## What this repo manages
-
-- **Cloudflare** — DNS zones, records, Pages projects, redirect rules (gpo.ca, gpotools.ca, gpotoolsstage.ca)
-- **GitHub** — Repository creation, branch settings, issue labels, Actions secrets
-- **GCP / GKE** — Kubernetes clusters (Toronto), Artifact Registry, GCP projects, service accounts
-- **AWS / EKS** — EKS clusters, VPC networking, ECR, IAM users
-- **Secrets** — SOPS-encrypted secrets, KMS keys (AWS + GCP)
-- **Bootstrap** — One-time account setup (GCP projects, AWS IAM, S3 state buckets)
-
----
+Infrastructure as Code for GPO, managed with OpenTofu. Covers Cloudflare (DNS, Pages), GitHub (repos, labels, secrets), GCP/GKE, AWS/EKS, and SOPS secrets.
 
 ## Stack layout
 
-All Terraform lives under `tf/`. There are four independent stacks, each with its own state file:
-
 ```
 tf/
-├── bootstrap/{prod,stage}/     # One-time account setup — run once, rarely touched
-├── infra/{singletons,prod,stage}/  # Clusters, zones, networks — shared infra
-├── app/{prod,stage}/           # Per-app resources — DNS, secrets, IAM bindings
-└── modules/                    # Reusable modules (never deployed directly)
-    ├── app/
-    ├── bootstrap/
-    └── infra/
+├── bootstrap/{prod,stage}/        # One-time account setup
+├── infra/{singletons,prod,stage}/ # Clusters, zones, networks
+├── app/{prod,stage}/              # Per-app DNS, secrets, IAM
+└── modules/{app,infra,bootstrap}/ # Reusable modules — never deployed directly
 ```
 
-Stacks are independent. `app` reads outputs from `infra` via `terraform_remote_state`. `infra` reads outputs from `bootstrap` the same way.
-
-**All state is stored in GCS bucket `gpo-tf-state-data`**, organised by path:
-
-| Stack | GCS prefix |
-|---|---|
-| bootstrap/prod | `prod/bootstrap` |
-| bootstrap/stage | `stage/bootstrap` |
-| infra/prod | `prod/infra` |
-| infra/stage | `stage/infra` |
-| infra/singletons | `infra/singletons` |
-| app/prod | `prod/app` |
-| app/stage | `stage/app` |
-
----
-
-## Critical rules — read before touching anything
-
-1. **Never run `tofu apply` on `app/` with default parallelism.** GCP rate-limits concurrent API calls. Always use:
-   ```
-   tofu apply -parallelism=1
-   ```
-2. **Secrets are SOPS-encrypted.** Never commit plaintext secrets. Source files: `secrets.env` (shared), `secrets.prod.env`, `secrets.stage.env` in the repo root.
-3. **Two AWS CLI profiles are required:** `gpo-prod` (account 060795914812) and `gpo-stage` (account 542371827759), both `ca-central-1`.
-4. **Singletons are global** — changes to `tf/infra/singletons/` affect live production immediately (gpo.ca DNS, GitHub repos, etc.).
-5. **Don't put Kubernetes resources in Terraform** — K8s manifests live separately. TF manages cloud-provider resources only.
-
----
-
-## Provider versions
-
-| Provider | Version used in `infra/` + singletons | Version used in `app/` |
-|---|---|---|
-| cloudflare/cloudflare | 4.48.0 | 5.15.0 |
-| integrations/github | 6.4.0 | — |
-| carlpett/sops | 0.7.2 | 0.7.2 |
-| hashicorp/aws | 5.81 | 5.81 |
-| hashicorp/google | 7.12.0 | 7.12.0 |
-| digitalocean/digitalocean | 2.46.1 | 2.46.1 |
-
----
+`app` reads remote state from `infra`, which reads remote state from `bootstrap`. Singletons are independent and **global** — changes affect live production immediately.
 
 ## Naming conventions
 
-- Resource names: `snake_case`, qualified with environment where needed (e.g. `cloudflare_record.staging_gpo_ca`)
-- Module output objects for Cloudflare zones: `{ id = string, zone = string }`
-- DNS record `name` attribute: always the **full FQDN** (e.g. `"staging.gpo.ca"`, not `"staging"`)
-- TTL: always `1` when `proxied = true`, otherwise `300`
-- Toggle flags: use `locals {}` block, not `variable {}`, so no `-var` flags are needed at apply time
-
----
-
-## How to apply changes
-
-```bash
-cd tf/<stack>/<environment>
-tofu init        # first time or after provider changes
-tofu plan
-tofu apply       # add -parallelism=1 for app/ stacks
-```
-
-To apply all stacks at once, use the `tofu-all` helper script in the repo root.
-
----
+- Resource names: `snake_case`, environment-qualified where needed (e.g. `cloudflare_record.staging_gpo_ca`)
+- Cloudflare zone variable shape: `{ id = string, zone = string }`
+- DNS `name` attribute: always the full FQDN (`"staging.gpo.ca"`, not `"staging"`)
+- TTL: `1` when `proxied = true`, `300` otherwise
+- Toggle flags: `locals {}` block, not `variable {}` (avoids `-var` flags at apply time)
 
 ## Documentation index
 
-Read only the doc relevant to your task:
-
 | Task | Doc |
 |---|---|
-| Add or change DNS records / Cloudflare zones | [docs/cloudflare-dns.md](docs/cloudflare-dns.md) |
+| Add or change DNS records / zones | [docs/cloudflare-dns.md](docs/cloudflare-dns.md) |
 | Deploy a Cloudflare Pages site | [docs/cloudflare-pages.md](docs/cloudflare-pages.md) |
 | Create or configure a GitHub repository | [docs/github-repos.md](docs/github-repos.md) |
-| Work with GKE, GCP projects, or Artifact Registry | [docs/gke-and-gcp.md](docs/gke-and-gcp.md) |
-| Work with EKS, VPC, or ECR | [docs/aws-eks.md](docs/aws-eks.md) |
-| Add or rotate secrets / SOPS | [docs/secrets-and-sops.md](docs/secrets-and-sops.md) |
+| GKE, GCP projects, Artifact Registry | [docs/gke-and-gcp.md](docs/gke-and-gcp.md) |
+| EKS, VPC, ECR | [docs/aws-eks.md](docs/aws-eks.md) |
+| Secrets and SOPS | [docs/secrets-and-sops.md](docs/secrets-and-sops.md) |
 | Add an IAM user (AWS or GCP) | [docs/iam-users.md](docs/iam-users.md) |
-| Understand stack boundaries or remote state wiring | [docs/stacks-and-state.md](docs/stacks-and-state.md) |
-| Add a new application to the app layer | [docs/app-layer.md](docs/app-layer.md) |
+| Stack boundaries and remote state wiring | [docs/stacks-and-state.md](docs/stacks-and-state.md) |
+| Add a new application | [docs/app-layer.md](docs/app-layer.md) |
 | Bootstrap a new cloud account | [docs/bootstrap.md](docs/bootstrap.md) |

--- a/docs/app-layer.md
+++ b/docs/app-layer.md
@@ -11,8 +11,6 @@ The app layer manages per-application cloud resources: DNS records, GCP service 
 
 The app layer reads zone IDs and the GKE ingress IP from the infra stack via remote state, then passes them into app modules.
 
-**Always apply with `-parallelism=1`** to avoid GCP API rate limits.
-
 ---
 
 ## Modules in use

--- a/docs/app-layer.md
+++ b/docs/app-layer.md
@@ -1,165 +1,27 @@
 # App Layer
 
-Relevant stacks: `tf/app/prod/`, `tf/app/stage/`
-Relevant modules: `tf/modules/app/`
+Stacks: `tf/app/prod/`, `tf/app/stage/`
+Modules: `tf/modules/app/`
 
----
+## Modules
 
-## Overview
-
-The app layer manages per-application cloud resources: DNS records, GCP service accounts, secret access grants, and external integrations. It does **not** manage Kubernetes resources directly — those live in separate manifests.
-
-The app layer reads zone IDs and the GKE ingress IP from the infra stack via remote state, then passes them into app modules.
-
----
-
-## Modules in use
-
-| Module | What it creates |
+| Module | Creates |
 |---|---|
-| `argocd` | DNS A record for `argocd.<zone>` |
-| `grassroots` | DNS A record for `grassroots.<zone>` |
-| `superset` | DNS A record for `superset.<zone>` |
-| `cert_manager` | Cloudflare API token (DNS-01 challenges) + GCP Secret Manager secret |
-| `external_secrets` | GCP service account + Secret Manager access grants |
-| `legacy_logging` | AWS IAM user + CloudWatch policy for DigitalOcean monitoring |
-| `bi_dashboards` | BigQuery dataset + 40 batches of CiviCRM → BigQuery data transfer jobs |
-| `drupal` | DigitalOcean Spaces bucket for Drupal file storage |
+| `argocd` | DNS A record `argocd.<zone>` |
+| `grassroots` | DNS A record `grassroots.<zone>` |
+| `superset` | DNS A record `superset.<zone>` |
+| `cert_manager` | Scoped Cloudflare API token (DNS-01) + GCP Secret Manager secret |
+| `external_secrets` | GCP service account + Secret Manager access grants + Workload Identity binding |
+| `legacy_logging` | AWS IAM user `digital-ocean-monitoring` + CloudWatch policy |
+| `bi_dashboards` | BigQuery dataset `civicrm_tables` + 40 data transfer configs (CiviCRM → BQ) |
+| `drupal` | DigitalOcean Spaces bucket (`drupal` / `drupal-stage`) |
 
----
+## Wiring
 
-## How modules are wired in main.tf
+All modules receive `cloudflare_zone = { id, zone }` and `ingress_ip_address` from infra remote state. See `tf/app/prod/main.tf` for how modules are instantiated and `tf/app/prod/outputs.tf` for what gets exported for K8s consumption.
 
-```hcl
-# tf/app/prod/main.tf (simplified)
-module "grassroots" {
-  source = "../../modules/app/grassroots"
+## Adding a new app module
 
-  environment          = local.environment
-  ingress_ip_address   = data.terraform_remote_state.infra.outputs.gke_ingress_ip
-  cloudflare_zone      = data.terraform_remote_state.infra.outputs.cloudflare_zone_gpo_tools
-}
-```
-
-The `cloudflare_zone` object shape is `{ id = string, zone = string }`. All app modules that create DNS records expect this variable.
-
----
-
-## Adding a new application
-
-### 1. Create the module
-
-Create a new directory under `tf/modules/app/my-app/`. At minimum:
-
-**`main.tf`** — the DNS record:
-```hcl
-locals {
-  hostname = "my-app.${var.cloudflare_zone.zone}"
-}
-
-resource "cloudflare_record" "my_app" {
-  zone_id = var.cloudflare_zone.id
-  name    = local.hostname
-  content = var.ingress_ip_address
-  type    = "A"
-  ttl     = 1
-  proxied = true
-}
-```
-
-**`variables.tf`**:
-```hcl
-variable "cloudflare_zone" {
-  type        = object({ id = string, zone = string })
-  description = "The Cloudflare zone on which to create DNS records."
-}
-
-variable "ingress_ip_address" {
-  type        = string
-  description = "GKE ingress IP address."
-}
-
-variable "environment" {
-  type        = string
-  validation {
-    condition     = contains(["prod", "stage"], var.environment)
-    error_message = "Must be prod or stage."
-  }
-}
-```
-
-**`outputs.tf`**:
-```hcl
-output "hostname" {
-  value = local.hostname
-}
-```
-
-**`tofu.tf`** (if using Cloudflare provider):
-```hcl
-terraform {
-  required_providers {
-    cloudflare = { source = "cloudflare/cloudflare" }
-  }
-}
-```
-
-### 2. Instantiate in app/prod and app/stage
-
-In `tf/app/prod/main.tf` and `tf/app/stage/main.tf`:
-```hcl
-module "my_app" {
-  source = "../../modules/app/my-app"
-
-  environment        = local.environment
-  ingress_ip_address = data.terraform_remote_state.infra.outputs.gke_ingress_ip
-  cloudflare_zone    = data.terraform_remote_state.infra.outputs.cloudflare_zone_gpo_tools
-}
-```
-
-### 3. Add outputs if K8s needs them
-
-In `tf/app/prod/outputs.tf`, export anything K8s manifests need (hostname, service account emails, etc.):
-```hcl
-output "my-app" {
-  value = {
-    hostname = module.my_app.hostname
-  }
-}
-```
-
----
-
-## cert_manager module
-
-Creates a scoped Cloudflare API token for DNS-01 ACME challenges, then stores it in GCP Secret Manager so cert-manager running in GKE can access it via External Secrets.
-
-Inputs: `cloudflare_zone`, `cloudflare_account_id`, `environment`
-Output: `gsm_secret_name`
-
----
-
-## external_secrets module
-
-Creates a GCP service account (`external-secrets`) and grants it `roles/secretmanager.secretAccessor` on specific secrets. Also binds Workload Identity so the K8s `external-secrets/external-secrets` service account can impersonate it without a key file.
-
-To grant access to additional secrets, pass them via the `secrets` variable:
-```hcl
-module "external_secrets" {
-  source  = "../../modules/app/external_secrets"
-  secrets = ["my-new-secret-name"]
-}
-```
-
-Note: `superset-config`, `superset-env`, and `superset-postgres-db` are hardcoded in the module as always-required.
-
----
-
-## bi_dashboards module
-
-Transfers CiviCRM MySQL tables to BigQuery for analytics. Creates:
-- BigQuery dataset `civicrm_tables`
-- 40 `google_bigquery_data_transfer_config` resources, each moving 5 tables
-- Transfers scheduled at 1-minute intervals (00:00 through 00:39) to avoid rate limiting
-
-This module is compute-heavy at plan/apply time. Runs in `tf/app/prod/` only (not stage).
+1. Create `tf/modules/app/<name>/` — follow any existing module as a pattern
+2. Instantiate in `tf/app/prod/main.tf` and `tf/app/stage/main.tf`
+3. Export needed values (hostname, service account, etc.) in `tf/app/{prod,stage}/outputs.tf`

--- a/docs/app-layer.md
+++ b/docs/app-layer.md
@@ -1,0 +1,167 @@
+# App Layer
+
+Relevant stacks: `tf/app/prod/`, `tf/app/stage/`
+Relevant modules: `tf/modules/app/`
+
+---
+
+## Overview
+
+The app layer manages per-application cloud resources: DNS records, GCP service accounts, secret access grants, and external integrations. It does **not** manage Kubernetes resources directly — those live in separate manifests.
+
+The app layer reads zone IDs and the GKE ingress IP from the infra stack via remote state, then passes them into app modules.
+
+**Always apply with `-parallelism=1`** to avoid GCP API rate limits.
+
+---
+
+## Modules in use
+
+| Module | What it creates |
+|---|---|
+| `argocd` | DNS A record for `argocd.<zone>` |
+| `grassroots` | DNS A record for `grassroots.<zone>` |
+| `superset` | DNS A record for `superset.<zone>` |
+| `cert_manager` | Cloudflare API token (DNS-01 challenges) + GCP Secret Manager secret |
+| `external_secrets` | GCP service account + Secret Manager access grants |
+| `legacy_logging` | AWS IAM user + CloudWatch policy for DigitalOcean monitoring |
+| `bi_dashboards` | BigQuery dataset + 40 batches of CiviCRM → BigQuery data transfer jobs |
+| `drupal` | DigitalOcean Spaces bucket for Drupal file storage |
+
+---
+
+## How modules are wired in main.tf
+
+```hcl
+# tf/app/prod/main.tf (simplified)
+module "grassroots" {
+  source = "../../modules/app/grassroots"
+
+  environment          = local.environment
+  ingress_ip_address   = data.terraform_remote_state.infra.outputs.gke_ingress_ip
+  cloudflare_zone      = data.terraform_remote_state.infra.outputs.cloudflare_zone_gpo_tools
+}
+```
+
+The `cloudflare_zone` object shape is `{ id = string, zone = string }`. All app modules that create DNS records expect this variable.
+
+---
+
+## Adding a new application
+
+### 1. Create the module
+
+Create a new directory under `tf/modules/app/my-app/`. At minimum:
+
+**`main.tf`** — the DNS record:
+```hcl
+locals {
+  hostname = "my-app.${var.cloudflare_zone.zone}"
+}
+
+resource "cloudflare_record" "my_app" {
+  zone_id = var.cloudflare_zone.id
+  name    = local.hostname
+  content = var.ingress_ip_address
+  type    = "A"
+  ttl     = 1
+  proxied = true
+}
+```
+
+**`variables.tf`**:
+```hcl
+variable "cloudflare_zone" {
+  type        = object({ id = string, zone = string })
+  description = "The Cloudflare zone on which to create DNS records."
+}
+
+variable "ingress_ip_address" {
+  type        = string
+  description = "GKE ingress IP address."
+}
+
+variable "environment" {
+  type        = string
+  validation {
+    condition     = contains(["prod", "stage"], var.environment)
+    error_message = "Must be prod or stage."
+  }
+}
+```
+
+**`outputs.tf`**:
+```hcl
+output "hostname" {
+  value = local.hostname
+}
+```
+
+**`tofu.tf`** (if using Cloudflare provider):
+```hcl
+terraform {
+  required_providers {
+    cloudflare = { source = "cloudflare/cloudflare" }
+  }
+}
+```
+
+### 2. Instantiate in app/prod and app/stage
+
+In `tf/app/prod/main.tf` and `tf/app/stage/main.tf`:
+```hcl
+module "my_app" {
+  source = "../../modules/app/my-app"
+
+  environment        = local.environment
+  ingress_ip_address = data.terraform_remote_state.infra.outputs.gke_ingress_ip
+  cloudflare_zone    = data.terraform_remote_state.infra.outputs.cloudflare_zone_gpo_tools
+}
+```
+
+### 3. Add outputs if K8s needs them
+
+In `tf/app/prod/outputs.tf`, export anything K8s manifests need (hostname, service account emails, etc.):
+```hcl
+output "my-app" {
+  value = {
+    hostname = module.my_app.hostname
+  }
+}
+```
+
+---
+
+## cert_manager module
+
+Creates a scoped Cloudflare API token for DNS-01 ACME challenges, then stores it in GCP Secret Manager so cert-manager running in GKE can access it via External Secrets.
+
+Inputs: `cloudflare_zone`, `cloudflare_account_id`, `environment`
+Output: `gsm_secret_name`
+
+---
+
+## external_secrets module
+
+Creates a GCP service account (`external-secrets`) and grants it `roles/secretmanager.secretAccessor` on specific secrets. Also binds Workload Identity so the K8s `external-secrets/external-secrets` service account can impersonate it without a key file.
+
+To grant access to additional secrets, pass them via the `secrets` variable:
+```hcl
+module "external_secrets" {
+  source  = "../../modules/app/external_secrets"
+  secrets = ["my-new-secret-name"]
+}
+```
+
+Note: `superset-config`, `superset-env`, and `superset-postgres-db` are hardcoded in the module as always-required.
+
+---
+
+## bi_dashboards module
+
+Transfers CiviCRM MySQL tables to BigQuery for analytics. Creates:
+- BigQuery dataset `civicrm_tables`
+- 40 `google_bigquery_data_transfer_config` resources, each moving 5 tables
+- Transfers scheduled at 1-minute intervals (00:00 through 00:39) to avoid rate limiting
+
+This module is compute-heavy at plan/apply time. Runs in `tf/app/prod/` only (not stage).

--- a/docs/aws-eks.md
+++ b/docs/aws-eks.md
@@ -1,0 +1,117 @@
+# AWS EKS Infrastructure
+
+Relevant stacks: `tf/infra/prod/`, `tf/infra/stage/`
+Relevant modules: `tf/modules/infra/eks/`, `tf/modules/infra/vpc/`, `tf/modules/infra/ecr/`
+
+---
+
+## AWS accounts
+
+| Environment | Account ID | AWS CLI Profile |
+|---|---|---|
+| prod | 060795914812 | `gpo-prod` |
+| stage | 542371827759 | `gpo-stage` |
+
+Region: `ca-central-1` for both.
+
+Both profiles must be configured in `~/.aws/credentials` / `~/.aws/config` before running any `tofu` commands.
+
+---
+
+## VPC
+
+Module: `tf/modules/infra/vpc/`
+
+### What it creates
+
+| Resource | CIDR | AZ | Notes |
+|---|---|---|---|
+| VPC | `10.0.0.0/16` | — | With internet gateway |
+| Public subnet | `10.0.0.0/20` | `ca-central-1a` | NAT gateway lives here |
+| Private active subnet | `10.0.16.0/20` | `ca-central-1a` | EKS nodes run here |
+| Private inactive subnet | `10.0.32.0/20` | `ca-central-1b` | Required by EKS, no nodes |
+
+### Why two private subnets?
+
+EKS requires subnets in at least two availability zones. The `inactive` subnet exists solely to satisfy this requirement; no nodes are scheduled there.
+
+### Key output
+
+- `nat_gateway_public_ip` — the source IP for all outbound traffic from the cluster. Useful for allowlisting.
+
+---
+
+## EKS cluster
+
+Module: `tf/modules/infra/eks/`
+
+### What it creates
+
+- EKS cluster: `gpo-prod` / `gpo-stage`
+- Access mode: API-based (not config-map)
+- IAM role for the cluster with policies:
+  - `AmazonEKSClusterPolicy`
+  - `AmazonEKSComputePolicy`
+  - `AmazonEKSBlockStoragePolicy`
+  - `AmazonEKSLoadBalancingPolicy`
+  - `AmazonEKSNetworkingPolicy`
+- Managed node group in the active private subnet
+- Node IAM role with:
+  - `AmazonEKSWorkerNodePolicy`
+  - `AmazonEKS_CNI_Policy`
+  - `AmazonEC2ContainerRegistryPullOnly`
+
+### Node group scaling
+
+```hcl
+nodegroup_desired_size = ...
+nodegroup_min_size     = ...
+nodegroup_max_size     = ...
+```
+
+The `desired_size` change is **ignored by Terraform** (`ignore_changes = [scaling_config[0].desired_size]`) — the cluster autoscaler manages desired count at runtime.
+
+### User access
+
+Access entries are created for each user ARN in `var.admin_user_arns` and `var.eks_user_arns`:
+
+| User type | Policy |
+|---|---|
+| Admin | `AmazonEKSClusterAdminPolicy` |
+| EKS user | `AmazonEKSAdminPolicy` |
+
+---
+
+## ECR (Elastic Container Registry)
+
+Module: `tf/modules/infra/ecr/`
+
+### What it creates
+
+- One ECR repository per name in `var.repositories`
+- Repository path: `gpo/<name>`
+- Lifecycle policy: keep last 30 images, expire older ones
+
+### Adding a new ECR repository
+
+In `tf/infra/{prod,stage}/main.tf`, add the repo name to the `repositories` list in the `ecr` module call:
+
+```hcl
+module "ecr" {
+  source       = "../../modules/infra/ecr"
+  repositories = ["existing-repo", "my-new-repo"]
+}
+```
+
+---
+
+## AWS provider configuration
+
+```hcl
+provider "aws" {
+  profile = "gpo-prod"   # or "gpo-stage"
+  region  = "ca-central-1"
+}
+```
+
+The profile name comes from the local `environment` value. Bootstrap state provides IAM user ARNs to downstream stacks.

--- a/docs/aws-eks.md
+++ b/docs/aws-eks.md
@@ -1,117 +1,30 @@
-# AWS EKS Infrastructure
+# AWS / EKS
 
-Relevant stacks: `tf/infra/prod/`, `tf/infra/stage/`
-Relevant modules: `tf/modules/infra/eks/`, `tf/modules/infra/vpc/`, `tf/modules/infra/ecr/`
+Modules: `tf/modules/infra/eks/`, `tf/modules/infra/vpc/`, `tf/modules/infra/ecr/`
+Instantiated in: `tf/infra/prod/main.tf`, `tf/infra/stage/main.tf`
 
----
+## Accounts and profiles
 
-## AWS accounts
-
-| Environment | Account ID | AWS CLI Profile |
+| Environment | Account ID | AWS CLI profile |
 |---|---|---|
-| prod | 060795914812 | `gpo-prod` |
-| stage | 542371827759 | `gpo-stage` |
+| prod | `060795914812` | `gpo-prod` |
+| stage | `542371827759` | `gpo-stage` |
 
 Region: `ca-central-1` for both.
 
-Both profiles must be configured in `~/.aws/credentials` / `~/.aws/config` before running any `tofu` commands.
+## VPC layout
 
----
+CIDR `10.0.0.0/16`. Three subnets:
+- Public `10.0.0.0/20` (ca-central-1a) — NAT gateway lives here
+- Private active `10.0.16.0/20` (ca-central-1a) — EKS nodes
+- Private inactive `10.0.32.0/20` (ca-central-1b) — required by EKS, no nodes
 
-## VPC
+`nat_gateway_public_ip` output = source IP for all outbound cluster traffic.
 
-Module: `tf/modules/infra/vpc/`
+## EKS
 
-### What it creates
+Cluster `gpo-prod` / `gpo-stage`. `desired_size` is ignored by Terraform (managed by cluster autoscaler). User access via EKS access entries — ARNs flow from bootstrap outputs.
 
-| Resource | CIDR | AZ | Notes |
-|---|---|---|---|
-| VPC | `10.0.0.0/16` | — | With internet gateway |
-| Public subnet | `10.0.0.0/20` | `ca-central-1a` | NAT gateway lives here |
-| Private active subnet | `10.0.16.0/20` | `ca-central-1a` | EKS nodes run here |
-| Private inactive subnet | `10.0.32.0/20` | `ca-central-1b` | Required by EKS, no nodes |
+## ECR
 
-### Why two private subnets?
-
-EKS requires subnets in at least two availability zones. The `inactive` subnet exists solely to satisfy this requirement; no nodes are scheduled there.
-
-### Key output
-
-- `nat_gateway_public_ip` — the source IP for all outbound traffic from the cluster. Useful for allowlisting.
-
----
-
-## EKS cluster
-
-Module: `tf/modules/infra/eks/`
-
-### What it creates
-
-- EKS cluster: `gpo-prod` / `gpo-stage`
-- Access mode: API-based (not config-map)
-- IAM role for the cluster with policies:
-  - `AmazonEKSClusterPolicy`
-  - `AmazonEKSComputePolicy`
-  - `AmazonEKSBlockStoragePolicy`
-  - `AmazonEKSLoadBalancingPolicy`
-  - `AmazonEKSNetworkingPolicy`
-- Managed node group in the active private subnet
-- Node IAM role with:
-  - `AmazonEKSWorkerNodePolicy`
-  - `AmazonEKS_CNI_Policy`
-  - `AmazonEC2ContainerRegistryPullOnly`
-
-### Node group scaling
-
-```hcl
-nodegroup_desired_size = ...
-nodegroup_min_size     = ...
-nodegroup_max_size     = ...
-```
-
-The `desired_size` change is **ignored by Terraform** (`ignore_changes = [scaling_config[0].desired_size]`) — the cluster autoscaler manages desired count at runtime.
-
-### User access
-
-Access entries are created for each user ARN in `var.admin_user_arns` and `var.eks_user_arns`:
-
-| User type | Policy |
-|---|---|
-| Admin | `AmazonEKSClusterAdminPolicy` |
-| EKS user | `AmazonEKSAdminPolicy` |
-
----
-
-## ECR (Elastic Container Registry)
-
-Module: `tf/modules/infra/ecr/`
-
-### What it creates
-
-- One ECR repository per name in `var.repositories`
-- Repository path: `gpo/<name>`
-- Lifecycle policy: keep last 30 images, expire older ones
-
-### Adding a new ECR repository
-
-In `tf/infra/{prod,stage}/main.tf`, add the repo name to the `repositories` list in the `ecr` module call:
-
-```hcl
-module "ecr" {
-  source       = "../../modules/infra/ecr"
-  repositories = ["existing-repo", "my-new-repo"]
-}
-```
-
----
-
-## AWS provider configuration
-
-```hcl
-provider "aws" {
-  profile = "gpo-prod"   # or "gpo-stage"
-  region  = "ca-central-1"
-}
-```
-
-The profile name comes from the local `environment` value. Bootstrap state provides IAM user ARNs to downstream stacks.
+Repos named `gpo/<name>`. Lifecycle: keep last 30 images. Add repos by extending the `repositories` list in the `ecr` module call in `tf/infra/{prod,stage}/main.tf`.

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -92,7 +92,7 @@ If bootstrapping a brand new environment:
 2. Run `tofu apply` in `tf/bootstrap/{prod,stage}/`
 3. Retrieve initial user passwords: `tofu output -json | jq '.user_creds.value'`
 4. Run `tofu apply` in `tf/infra/{prod,stage}/`
-5. Run `tofu apply -parallelism=1` in `tf/app/{prod,stage}/`
+5. Run `tofu apply` in `tf/app/{prod,stage}/`
 
 `tf/infra/singletons/` can be applied at any point — it has no dependencies on other stacks.
 

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -1,116 +1,28 @@
 # Bootstrap
 
-Relevant stacks: `tf/bootstrap/prod/`, `tf/bootstrap/stage/`
-Relevant modules: `tf/modules/bootstrap/`
+Stacks: `tf/bootstrap/prod/`, `tf/bootstrap/stage/`
+Modules: `tf/modules/bootstrap/`
 
----
+Run once per environment. Rarely touched after initial setup.
 
-## Overview
+## What it creates
 
-The bootstrap stacks are run **once** when setting up a new environment. They create the foundational resources that all other stacks depend on:
+- **`iam_users`** — AWS IAM admin + EKS users, groups, login profiles
+- **`state_bucket`** — S3 bucket (versioned) + DynamoDB lock table
+- **`sops`** — AWS KMS key + GCP KMS key ring/crypto key for secret encryption (`prevent_destroy = true`)
+- **`apis`** — enables `secretmanager.googleapis.com`
+- **`gcp_iam_devs_stage`** (stage only) — per-developer GCP access, iterated from `local.dev_users`
 
-- AWS IAM users and groups
-- S3 bucket and DynamoDB table for Terraform state
-- SOPS encryption keys (AWS KMS + GCP KMS)
-- GCP projects
-- GCP API enablement
+## GCP projects created
 
-> **Do not run bootstrap stacks regularly.** They are designed for initial setup only. Day-to-day changes go in `infra/` or `app/`.
+`gpo-eng-prod` + `gpo-data-prod` (prod) · `gpo-eng-stage` + `calm-segment-466901-e4` (stage)
+Org: `267619224561` · Billing: `019C4D-E56387-A59CAF`
 
----
+## First-time apply order
 
-## What each module creates
+1. Manually create GCS bucket `gpo-tf-state-data`
+2. Apply `tf/bootstrap/{prod,stage}/`
+3. Apply `tf/infra/{prod,stage}/`
+4. Apply `tf/app/{prod,stage}/`
 
-### `iam_users`
-
-- AWS IAM users for `iam_admin_users` list → `admin` group with `AdministratorAccess`
-- AWS IAM users for `iam_eks_users` list → `eks` group with scoped access
-- Login profiles with forced password change on first login
-- See [docs/iam-users.md](iam-users.md) for how to add users
-
-### `state_bucket`
-
-- S3 bucket for Terraform remote state (versioning + AES256 encryption)
-- DynamoDB table `terraform-state-locks` for state locking
-- `force_destroy = true` on the bucket (intentional for bootstrap scenarios)
-
-### `sops`
-
-- AWS KMS key for SOPS encryption
-- GCP KMS key ring `sops-{environment}` + crypto key `sops-{environment}`
-- Both keys have `lifecycle { prevent_destroy = true }` — they **cannot** be deleted via Terraform
-- See [docs/secrets-and-sops.md](secrets-and-sops.md) for how secrets work
-
-### `apis`
-
-- Enables `secretmanager.googleapis.com` on the bootstrap GCP project
-
-### `gcp_iam_devs_stage` (stage only)
-
-- Per-developer GCP IAM grants (GAR write, GKE developer)
-- One module instance per email in `local.dev_users`
-- See [docs/iam-users.md](iam-users.md) for how to add developers
-
----
-
-## GCP projects
-
-Two GCP projects are created per environment in `tf/bootstrap/{prod,stage}/gcp_projects.tf`:
-
-| Project resource | Project ID | Purpose |
-|---|---|---|
-| `google_project.gpo_data` | `gpo-data-prod` / stage equivalent | Data infrastructure |
-| `google_project.gpo_eng` | `gpo-eng-prod` / `gpo-eng-stage` | Engineering (GKE, GAR) |
-
-GCP organization: `267619224561`
-Billing account: `019C4D-E56387-A59CAF`
-
-Project IDs are exported as outputs and consumed by downstream stacks via remote state.
-
----
-
-## Bootstrap outputs
-
-Other stacks read these via `data.terraform_remote_state.bootstrap.outputs.*`:
-
-| Output | Type | Used by |
-|---|---|---|
-| `admin_user_arns` | list(string) | infra/eks module |
-| `eks_user_arns` | list(string) | infra/eks module |
-| `user_creds` | map (sensitive) | Retrieved manually after first apply |
-| `gcp_project_gpo_data` | object | infra providers |
-| `gcp_project_gpo_eng` | object | infra providers (GKE, GAR) |
-| `gcp_project_bootstrap` | string | sops module |
-
----
-
-## First-time setup sequence
-
-If bootstrapping a brand new environment:
-
-1. Manually create the GCS bucket `gpo-tf-state-data` (chicken-and-egg: the bucket must exist before Terraform can use it as a backend)
-2. Run `tofu apply` in `tf/bootstrap/{prod,stage}/`
-3. Retrieve initial user passwords: `tofu output -json | jq '.user_creds.value'`
-4. Run `tofu apply` in `tf/infra/{prod,stage}/`
-5. Run `tofu apply` in `tf/app/{prod,stage}/`
-
-`tf/infra/singletons/` can be applied at any point — it has no dependencies on other stacks.
-
----
-
-## Provider configuration
-
-Bootstrap uses three providers:
-
-```hcl
-provider "aws" {
-  profile = "gpo-prod"   # or "gpo-stage"
-  region  = "ca-central-1"
-}
-
-provider "google" {
-  project = "gpo-bootstrap-2"  # the pre-existing bootstrap GCP project
-}
-```
-
-The `sops` provider requires no configuration block — it picks up AWS/GCP credentials from the environment.
+`tf/infra/singletons/` can be applied at any point.

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -1,0 +1,116 @@
+# Bootstrap
+
+Relevant stacks: `tf/bootstrap/prod/`, `tf/bootstrap/stage/`
+Relevant modules: `tf/modules/bootstrap/`
+
+---
+
+## Overview
+
+The bootstrap stacks are run **once** when setting up a new environment. They create the foundational resources that all other stacks depend on:
+
+- AWS IAM users and groups
+- S3 bucket and DynamoDB table for Terraform state
+- SOPS encryption keys (AWS KMS + GCP KMS)
+- GCP projects
+- GCP API enablement
+
+> **Do not run bootstrap stacks regularly.** They are designed for initial setup only. Day-to-day changes go in `infra/` or `app/`.
+
+---
+
+## What each module creates
+
+### `iam_users`
+
+- AWS IAM users for `iam_admin_users` list → `admin` group with `AdministratorAccess`
+- AWS IAM users for `iam_eks_users` list → `eks` group with scoped access
+- Login profiles with forced password change on first login
+- See [docs/iam-users.md](iam-users.md) for how to add users
+
+### `state_bucket`
+
+- S3 bucket for Terraform remote state (versioning + AES256 encryption)
+- DynamoDB table `terraform-state-locks` for state locking
+- `force_destroy = true` on the bucket (intentional for bootstrap scenarios)
+
+### `sops`
+
+- AWS KMS key for SOPS encryption
+- GCP KMS key ring `sops-{environment}` + crypto key `sops-{environment}`
+- Both keys have `lifecycle { prevent_destroy = true }` — they **cannot** be deleted via Terraform
+- See [docs/secrets-and-sops.md](secrets-and-sops.md) for how secrets work
+
+### `apis`
+
+- Enables `secretmanager.googleapis.com` on the bootstrap GCP project
+
+### `gcp_iam_devs_stage` (stage only)
+
+- Per-developer GCP IAM grants (GAR write, GKE developer)
+- One module instance per email in `local.dev_users`
+- See [docs/iam-users.md](iam-users.md) for how to add developers
+
+---
+
+## GCP projects
+
+Two GCP projects are created per environment in `tf/bootstrap/{prod,stage}/gcp_projects.tf`:
+
+| Project resource | Project ID | Purpose |
+|---|---|---|
+| `google_project.gpo_data` | `gpo-data-prod` / stage equivalent | Data infrastructure |
+| `google_project.gpo_eng` | `gpo-eng-prod` / `gpo-eng-stage` | Engineering (GKE, GAR) |
+
+GCP organization: `267619224561`
+Billing account: `019C4D-E56387-A59CAF`
+
+Project IDs are exported as outputs and consumed by downstream stacks via remote state.
+
+---
+
+## Bootstrap outputs
+
+Other stacks read these via `data.terraform_remote_state.bootstrap.outputs.*`:
+
+| Output | Type | Used by |
+|---|---|---|
+| `admin_user_arns` | list(string) | infra/eks module |
+| `eks_user_arns` | list(string) | infra/eks module |
+| `user_creds` | map (sensitive) | Retrieved manually after first apply |
+| `gcp_project_gpo_data` | object | infra providers |
+| `gcp_project_gpo_eng` | object | infra providers (GKE, GAR) |
+| `gcp_project_bootstrap` | string | sops module |
+
+---
+
+## First-time setup sequence
+
+If bootstrapping a brand new environment:
+
+1. Manually create the GCS bucket `gpo-tf-state-data` (chicken-and-egg: the bucket must exist before Terraform can use it as a backend)
+2. Run `tofu apply` in `tf/bootstrap/{prod,stage}/`
+3. Retrieve initial user passwords: `tofu output -json | jq '.user_creds.value'`
+4. Run `tofu apply` in `tf/infra/{prod,stage}/`
+5. Run `tofu apply -parallelism=1` in `tf/app/{prod,stage}/`
+
+`tf/infra/singletons/` can be applied at any point — it has no dependencies on other stacks.
+
+---
+
+## Provider configuration
+
+Bootstrap uses three providers:
+
+```hcl
+provider "aws" {
+  profile = "gpo-prod"   # or "gpo-stage"
+  region  = "ca-central-1"
+}
+
+provider "google" {
+  project = "gpo-bootstrap-2"  # the pre-existing bootstrap GCP project
+}
+```
+
+The `sops` provider requires no configuration block — it picks up AWS/GCP credentials from the environment.

--- a/docs/cloudflare-dns.md
+++ b/docs/cloudflare-dns.md
@@ -1,142 +1,30 @@
 # Cloudflare DNS
 
-Relevant stack: `tf/infra/singletons/`
+## Zones
 
----
-
-## Zones managed
-
-| Zone | Resource | Stack |
+| Zone | Resource | File |
 |---|---|---|
-| `gpo.ca` | `cloudflare_zone.gpo_ca` | `infra/singletons` |
-| `gpotools.ca` | `cloudflare_zone.gpo_tools` | `infra/prod` |
-| `gpotoolsstage.ca` | `cloudflare_zone.gpo_tools` | `infra/stage` |
+| `gpo.ca` | `cloudflare_zone.gpo_ca` | `tf/infra/singletons/cloudflare_domains.tf` |
+| `gpotools.ca` | `cloudflare_zone.gpo_tools` | `tf/infra/prod/cloudflare_zone.tf` |
+| `gpotoolsstage.ca` | `cloudflare_zone.gpo_tools` | `tf/infra/stage/cloudflare_zone.tf` |
 
-The `gpo.ca` zone is defined in `tf/infra/singletons/cloudflare_domains.tf` and is the **primary production domain**. Changes here affect live traffic immediately.
+`gpo.ca` is global/production — no staging equivalent.
 
----
+## Conventions
 
-## Provider config
+- Resource names: `cloudflare_record.<subdomain>_gpo_ca` (dots and leading digits → underscores, e.g. `_1997_gpo_ca`, `s1__domainkey_gpo_ca`)
+- `name` is always the full FQDN
+- `ttl = 1` when `proxied = true`, `ttl = 300` otherwise
+- Auth: `cloudflare_api_key` and `cloudflare_account_id` from SOPS (`tf/infra/singletons/secrets.tf`)
 
-Cloudflare provider v4.48.0 is used in `infra/` and singletons. Auth via SOPS secrets:
+## Zone ID by context
 
-```hcl
-provider "cloudflare" {
-  email   = "ianedington@gpo.ca"
-  api_key = data.sops_file.secrets.data["cloudflare_api_key"]
-}
-```
-
-Account ID is also sourced from SOPS:
-```hcl
-account_id = data.sops_file.secrets.data["cloudflare_account_id"]
-```
-
----
-
-## Adding a DNS record to gpo.ca
-
-All `gpo.ca` records live in `tf/infra/singletons/cloudflare_domains.tf`.
-
-**Naming convention:** `cloudflare_record.<subdomain>_gpo_ca`, replacing dots and leading digits with underscores. Examples:
-- `1997.gpo.ca` → `cloudflare_record._1997_gpo_ca`
-- `staging.gpo.ca` → `cloudflare_record.staging_gpo_ca`
-- `s1._domainkey.gpo.ca` → `cloudflare_record.s1__domainkey_gpo_ca`
-
-**Template for a proxied A record:**
-```hcl
-resource "cloudflare_record" "myapp_gpo_ca" {
-  zone_id = cloudflare_zone.gpo_ca.id
-  name    = "myapp.gpo.ca"   # always full FQDN
-  content = "1.2.3.4"
-  type    = "A"
-  ttl     = 1                # must be 1 when proxied = true
-  proxied = true
-}
-```
-
-**Template for a non-proxied CNAME:**
-```hcl
-resource "cloudflare_record" "myapp_gpo_ca" {
-  zone_id = cloudflare_zone.gpo_ca.id
-  name    = "myapp.gpo.ca"
-  content = "target.example.com"
-  type    = "CNAME"
-  ttl     = 300
-}
-```
-
-**TTL rule:** `ttl = 1` when `proxied = true`. Use `ttl = 300` when not proxied.
-
----
-
-## Adding a DNS record to gpotools.ca / gpotoolsstage.ca
-
-These zones are output from `infra/prod` and `infra/stage` and consumed by the `app/` layer via remote state. App-layer modules receive the zone as a variable:
-
-```hcl
-variable "cloudflare_zone" {
-  type = object({ id = string, zone = string })
-}
-```
-
-DNS records for apps in the `app/` layer are created inside modules under `tf/modules/app/<module-name>/`. The zone object is passed in from `tf/app/{prod,stage}/main.tf`.
-
-Example (from the `grassroots` module):
-```hcl
-resource "cloudflare_record" "grassroots" {
-  zone_id = var.cloudflare_zone.id
-  name    = "grassroots.${var.cloudflare_zone.zone}"
-  content = var.ingress_ip_address
-  type    = "A"
-  ttl     = 1
-  proxied = true
-}
-```
-
----
+| Where | Expression |
+|---|---|
+| `infra/singletons` | `cloudflare_zone.gpo_ca.id` |
+| `infra/prod` or `infra/stage` | `cloudflare_zone.gpo_tools.id` |
+| `app/` layer or modules | `var.cloudflare_zone.id` (passed via remote state) |
 
 ## Redirect rules
 
-Redirect rules use `cloudflare_ruleset` with `phase = "http_request_dynamic_redirect"`. Use `count` driven by a local to toggle on/off without `-var` flags. See `tf/infra/singletons/cloudflare_april_fools.tf` for a working example.
-
-```hcl
-locals {
-  my_redirect_enabled = false  # flip to true, then tofu apply
-}
-
-resource "cloudflare_ruleset" "my_redirect" {
-  count       = local.my_redirect_enabled ? 1 : 0
-  zone_id     = cloudflare_zone.gpo_ca.id
-  name        = "My Redirect"
-  kind        = "zone"
-  phase       = "http_request_dynamic_redirect"
-
-  rules {
-    action = "redirect"
-    action_parameters {
-      from_value {
-        status_code = 302
-        target_url {
-          value = "https://destination.example.com"
-        }
-        preserve_query_string = false
-      }
-    }
-    expression  = "(http.host eq \"gpo.ca\")"
-    description = "Redirect description"
-    enabled     = true
-  }
-}
-```
-
----
-
-## Zone ID reference cheatsheet
-
-| Where you're working | How to get the zone ID |
-|---|---|
-| `infra/singletons` | `cloudflare_zone.gpo_ca.id` |
-| `infra/prod` | `cloudflare_zone.gpo_tools.id` |
-| `infra/stage` | `cloudflare_zone.gpo_tools.id` |
-| `app/{prod,stage}` or a module | `var.cloudflare_zone.id` (passed from remote state) |
+Use `cloudflare_ruleset` with `phase = "http_request_dynamic_redirect"` and a `locals {}` toggle. See `tf/infra/singletons/cloudflare_april_fools.tf` for a working example.

--- a/docs/cloudflare-dns.md
+++ b/docs/cloudflare-dns.md
@@ -1,0 +1,142 @@
+# Cloudflare DNS
+
+Relevant stack: `tf/infra/singletons/`
+
+---
+
+## Zones managed
+
+| Zone | Resource | Stack |
+|---|---|---|
+| `gpo.ca` | `cloudflare_zone.gpo_ca` | `infra/singletons` |
+| `gpotools.ca` | `cloudflare_zone.gpo_tools` | `infra/prod` |
+| `gpotoolsstage.ca` | `cloudflare_zone.gpo_tools` | `infra/stage` |
+
+The `gpo.ca` zone is defined in `tf/infra/singletons/cloudflare_domains.tf` and is the **primary production domain**. Changes here affect live traffic immediately.
+
+---
+
+## Provider config
+
+Cloudflare provider v4.48.0 is used in `infra/` and singletons. Auth via SOPS secrets:
+
+```hcl
+provider "cloudflare" {
+  email   = "ianedington@gpo.ca"
+  api_key = data.sops_file.secrets.data["cloudflare_api_key"]
+}
+```
+
+Account ID is also sourced from SOPS:
+```hcl
+account_id = data.sops_file.secrets.data["cloudflare_account_id"]
+```
+
+---
+
+## Adding a DNS record to gpo.ca
+
+All `gpo.ca` records live in `tf/infra/singletons/cloudflare_domains.tf`.
+
+**Naming convention:** `cloudflare_record.<subdomain>_gpo_ca`, replacing dots and leading digits with underscores. Examples:
+- `1997.gpo.ca` → `cloudflare_record._1997_gpo_ca`
+- `staging.gpo.ca` → `cloudflare_record.staging_gpo_ca`
+- `s1._domainkey.gpo.ca` → `cloudflare_record.s1__domainkey_gpo_ca`
+
+**Template for a proxied A record:**
+```hcl
+resource "cloudflare_record" "myapp_gpo_ca" {
+  zone_id = cloudflare_zone.gpo_ca.id
+  name    = "myapp.gpo.ca"   # always full FQDN
+  content = "1.2.3.4"
+  type    = "A"
+  ttl     = 1                # must be 1 when proxied = true
+  proxied = true
+}
+```
+
+**Template for a non-proxied CNAME:**
+```hcl
+resource "cloudflare_record" "myapp_gpo_ca" {
+  zone_id = cloudflare_zone.gpo_ca.id
+  name    = "myapp.gpo.ca"
+  content = "target.example.com"
+  type    = "CNAME"
+  ttl     = 300
+}
+```
+
+**TTL rule:** `ttl = 1` when `proxied = true`. Use `ttl = 300` when not proxied.
+
+---
+
+## Adding a DNS record to gpotools.ca / gpotoolsstage.ca
+
+These zones are output from `infra/prod` and `infra/stage` and consumed by the `app/` layer via remote state. App-layer modules receive the zone as a variable:
+
+```hcl
+variable "cloudflare_zone" {
+  type = object({ id = string, zone = string })
+}
+```
+
+DNS records for apps in the `app/` layer are created inside modules under `tf/modules/app/<module-name>/`. The zone object is passed in from `tf/app/{prod,stage}/main.tf`.
+
+Example (from the `grassroots` module):
+```hcl
+resource "cloudflare_record" "grassroots" {
+  zone_id = var.cloudflare_zone.id
+  name    = "grassroots.${var.cloudflare_zone.zone}"
+  content = var.ingress_ip_address
+  type    = "A"
+  ttl     = 1
+  proxied = true
+}
+```
+
+---
+
+## Redirect rules
+
+Redirect rules use `cloudflare_ruleset` with `phase = "http_request_dynamic_redirect"`. Use `count` driven by a local to toggle on/off without `-var` flags. See `tf/infra/singletons/cloudflare_april_fools.tf` for a working example.
+
+```hcl
+locals {
+  my_redirect_enabled = false  # flip to true, then tofu apply
+}
+
+resource "cloudflare_ruleset" "my_redirect" {
+  count       = local.my_redirect_enabled ? 1 : 0
+  zone_id     = cloudflare_zone.gpo_ca.id
+  name        = "My Redirect"
+  kind        = "zone"
+  phase       = "http_request_dynamic_redirect"
+
+  rules {
+    action = "redirect"
+    action_parameters {
+      from_value {
+        status_code = 302
+        target_url {
+          value = "https://destination.example.com"
+        }
+        preserve_query_string = false
+      }
+    }
+    expression  = "(http.host eq \"gpo.ca\")"
+    description = "Redirect description"
+    enabled     = true
+  }
+}
+```
+
+---
+
+## Zone ID reference cheatsheet
+
+| Where you're working | How to get the zone ID |
+|---|---|
+| `infra/singletons` | `cloudflare_zone.gpo_ca.id` |
+| `infra/prod` | `cloudflare_zone.gpo_tools.id` |
+| `infra/stage` | `cloudflare_zone.gpo_tools.id` |
+| `app/{prod,stage}` or a module | `var.cloudflare_zone.id` (passed from remote state) |

--- a/docs/cloudflare-pages.md
+++ b/docs/cloudflare-pages.md
@@ -1,0 +1,132 @@
+# Cloudflare Pages
+
+Relevant stack: `tf/infra/singletons/`
+
+---
+
+## Overview
+
+Cloudflare Pages projects are defined in `tf/infra/singletons/`. The provider version is 4.48.0. Three resources are needed to fully deploy a Pages site with a custom domain:
+
+1. `cloudflare_pages_project` — creates the project and wires up the GitHub repo
+2. `cloudflare_record` — CNAME pointing the custom subdomain at `<project>.pages.dev`
+3. `cloudflare_pages_domain` — attaches the custom domain to the project
+
+---
+
+## Pre-requisite: GitHub OAuth connection
+
+Before the first `tofu apply`, the **Cloudflare Pages → GitHub connection must be authorised manually** in the Cloudflare dashboard:
+
+**Workers & Pages → Overview → Settings → Integrations → GitHub**
+
+Terraform cannot create this OAuth connection. If it doesn't exist the `cloudflare_pages_project` apply will fail.
+
+---
+
+## Full example
+
+See `tf/infra/singletons/cloudflare_april_fools.tf` for a working reference. Template:
+
+```hcl
+resource "cloudflare_pages_project" "my_project" {
+  account_id        = data.sops_file.secrets.data["cloudflare_account_id"]
+  name              = "my-project-name"      # becomes <name>.pages.dev
+  production_branch = "main"
+
+  source {
+    type = "github"
+    config {
+      owner                         = "gpo"
+      repo_name                     = "my-repo"
+      production_branch             = "main"
+      pr_comments_enabled           = true
+      deployments_enabled           = true
+      production_deployment_enabled = true
+      preview_deployment_setting    = "none"  # "all", "custom", or "none"
+    }
+  }
+
+  build_config {
+    build_command   = ""   # empty = no build step
+    destination_dir = "/"  # serve from repo root
+  }
+}
+
+resource "cloudflare_record" "my_subdomain_gpo_ca" {
+  zone_id = cloudflare_zone.gpo_ca.id
+  name    = "myapp.gpo.ca"
+  content = cloudflare_pages_project.my_project.subdomain  # resolves to <name>.pages.dev
+  type    = "CNAME"
+  ttl     = 1
+  proxied = true
+}
+
+resource "cloudflare_pages_domain" "my_subdomain_gpo_ca" {
+  account_id   = data.sops_file.secrets.data["cloudflare_account_id"]
+  project_name = cloudflare_pages_project.my_project.name
+  domain       = "myapp.gpo.ca"
+}
+```
+
+---
+
+## source.config options
+
+| Option | Type | Default | Notes |
+|---|---|---|---|
+| `owner` | string | — | GitHub org or username |
+| `repo_name` | string | — | Repository name (no org prefix) |
+| `production_branch` | string | — | **Required.** Branch for prod deployments |
+| `deployments_enabled` | bool | `true` | Master switch for all deployments |
+| `production_deployment_enabled` | bool | `true` | Enable prod branch deploys |
+| `pr_comments_enabled` | bool | `true` | Post deployment URL on PRs |
+| `preview_deployment_setting` | string | `"all"` | `"all"`, `"none"`, or `"custom"` |
+| `preview_branch_includes` | list(string) | — | When setting is `"custom"`, branches to include |
+| `preview_branch_excludes` | list(string) | — | Branches to exclude from previews |
+
+---
+
+## build_config options
+
+| Option | Type | Notes |
+|---|---|---|
+| `build_command` | string | Empty string = no build. e.g. `"npm run build"` |
+| `destination_dir` | string | Output directory. `/` = repo root. e.g. `"dist"` |
+| `root_dir` | string | Monorepo subdirectory to use as project root |
+| `build_caching` | bool | Cache build dependencies between runs |
+| `web_analytics_tag` | string | Cloudflare Web Analytics dataset tag |
+| `web_analytics_token` | string | Auth token for Web Analytics |
+
+---
+
+## deployment_configs (Pages Functions)
+
+If the site uses **Cloudflare Pages Functions** (server-side Workers), add a `deployment_configs` block. Both `preview` and `production` sub-blocks accept:
+
+| Option | Notes |
+|---|---|
+| `environment_variables` | `map(string)` — runtime env vars |
+| `secrets` | `map(string)` — sensitive env vars (encrypted at rest) |
+| `kv_namespaces` | `map(string)` — Workers KV bindings |
+| `d1_databases` | `map(string)` — D1 SQLite bindings |
+| `r2_buckets` | `map(string)` — R2 object storage bindings |
+| `durable_object_namespaces` | `map(string)` — Durable Object bindings |
+| `service_binding` | Block — call another Worker from this Pages Function |
+| `compatibility_date` | Pin Workers runtime version |
+| `compatibility_flags` | Enable specific runtime features |
+| `usage_model` | `"bundled"`, `"unbound"`, or `"standard"` |
+| `fail_open` | Serve static site even if Function crashes |
+| `placement` | Smart Placement mode hint |
+
+Static sites with no Functions do not need `deployment_configs`.
+
+---
+
+## Computed attributes
+
+| Attribute | Value |
+|---|---|
+| `cloudflare_pages_project.<name>.subdomain` | Full `<project>.pages.dev` hostname |
+| `cloudflare_pages_project.<name>.domains` | List of attached custom domains |
+| `cloudflare_pages_project.<name>.created_on` | Creation timestamp |

--- a/docs/cloudflare-pages.md
+++ b/docs/cloudflare-pages.md
@@ -1,132 +1,19 @@
 # Cloudflare Pages
 
-Relevant stack: `tf/infra/singletons/`
+## Existing projects
 
----
-
-## Overview
-
-Cloudflare Pages projects are defined in `tf/infra/singletons/`. The provider version is 4.48.0. Three resources are needed to fully deploy a Pages site with a custom domain:
-
-1. `cloudflare_pages_project` — creates the project and wires up the GitHub repo
-2. `cloudflare_record` — CNAME pointing the custom subdomain at `<project>.pages.dev`
-3. `cloudflare_pages_domain` — attaches the custom domain to the project
-
----
-
-## Pre-requisite: GitHub OAuth connection
-
-Before the first `tofu apply`, the **Cloudflare Pages → GitHub connection must be authorised manually** in the Cloudflare dashboard:
-
-**Workers & Pages → Overview → Settings → Integrations → GitHub**
-
-Terraform cannot create this OAuth connection. If it doesn't exist the `cloudflare_pages_project` apply will fail.
-
----
-
-## Full example
-
-See `tf/infra/singletons/cloudflare_april_fools.tf` for a working reference. Template:
-
-```hcl
-resource "cloudflare_pages_project" "my_project" {
-  account_id        = data.sops_file.secrets.data["cloudflare_account_id"]
-  name              = "my-project-name"      # becomes <name>.pages.dev
-  production_branch = "main"
-
-  source {
-    type = "github"
-    config {
-      owner                         = "gpo"
-      repo_name                     = "my-repo"
-      production_branch             = "main"
-      pr_comments_enabled           = true
-      deployments_enabled           = true
-      production_deployment_enabled = true
-      preview_deployment_setting    = "none"  # "all", "custom", or "none"
-    }
-  }
-
-  build_config {
-    build_command   = ""   # empty = no build step
-    destination_dir = "/"  # serve from repo root
-  }
-}
-
-resource "cloudflare_record" "my_subdomain_gpo_ca" {
-  zone_id = cloudflare_zone.gpo_ca.id
-  name    = "myapp.gpo.ca"
-  content = cloudflare_pages_project.my_project.subdomain  # resolves to <name>.pages.dev
-  type    = "CNAME"
-  ttl     = 1
-  proxied = true
-}
-
-resource "cloudflare_pages_domain" "my_subdomain_gpo_ca" {
-  account_id   = data.sops_file.secrets.data["cloudflare_account_id"]
-  project_name = cloudflare_pages_project.my_project.name
-  domain       = "myapp.gpo.ca"
-}
-```
-
----
-
-## source.config options
-
-| Option | Type | Default | Notes |
+| Project name | Repo | Domain | File |
 |---|---|---|---|
-| `owner` | string | — | GitHub org or username |
-| `repo_name` | string | — | Repository name (no org prefix) |
-| `production_branch` | string | — | **Required.** Branch for prod deployments |
-| `deployments_enabled` | bool | `true` | Master switch for all deployments |
-| `production_deployment_enabled` | bool | `true` | Enable prod branch deploys |
-| `pr_comments_enabled` | bool | `true` | Post deployment URL on PRs |
-| `preview_deployment_setting` | string | `"all"` | `"all"`, `"none"`, or `"custom"` |
-| `preview_branch_includes` | list(string) | — | When setting is `"custom"`, branches to include |
-| `preview_branch_excludes` | list(string) | — | Branches to exclude from previews |
+| `1997-gpo-ca` | `gpo/1997` | `1997.gpo.ca` | `tf/infra/singletons/cloudflare_april_fools.tf` |
 
----
+## Three resources required per project
 
-## build_config options
+1. `cloudflare_pages_project` — wires the GitHub repo
+2. `cloudflare_record` (CNAME) — points subdomain at `<project>.pages.dev` via the computed `cloudflare_pages_project.<name>.subdomain` attribute
+3. `cloudflare_pages_domain` — attaches the custom domain
 
-| Option | Type | Notes |
-|---|---|---|
-| `build_command` | string | Empty string = no build. e.g. `"npm run build"` |
-| `destination_dir` | string | Output directory. `/` = repo root. e.g. `"dist"` |
-| `root_dir` | string | Monorepo subdirectory to use as project root |
-| `build_caching` | bool | Cache build dependencies between runs |
-| `web_analytics_tag` | string | Cloudflare Web Analytics dataset tag |
-| `web_analytics_token` | string | Auth token for Web Analytics |
+See `tf/infra/singletons/cloudflare_april_fools.tf` for the full working pattern.
 
----
+## Pre-requisite
 
-## deployment_configs (Pages Functions)
-
-If the site uses **Cloudflare Pages Functions** (server-side Workers), add a `deployment_configs` block. Both `preview` and `production` sub-blocks accept:
-
-| Option | Notes |
-|---|---|
-| `environment_variables` | `map(string)` — runtime env vars |
-| `secrets` | `map(string)` — sensitive env vars (encrypted at rest) |
-| `kv_namespaces` | `map(string)` — Workers KV bindings |
-| `d1_databases` | `map(string)` — D1 SQLite bindings |
-| `r2_buckets` | `map(string)` — R2 object storage bindings |
-| `durable_object_namespaces` | `map(string)` — Durable Object bindings |
-| `service_binding` | Block — call another Worker from this Pages Function |
-| `compatibility_date` | Pin Workers runtime version |
-| `compatibility_flags` | Enable specific runtime features |
-| `usage_model` | `"bundled"`, `"unbound"`, or `"standard"` |
-| `fail_open` | Serve static site even if Function crashes |
-| `placement` | Smart Placement mode hint |
-
-Static sites with no Functions do not need `deployment_configs`.
-
----
-
-## Computed attributes
-
-| Attribute | Value |
-|---|---|
-| `cloudflare_pages_project.<name>.subdomain` | Full `<project>.pages.dev` hostname |
-| `cloudflare_pages_project.<name>.domains` | List of attached custom domains |
-| `cloudflare_pages_project.<name>.created_on` | Creation timestamp |
+The Cloudflare Pages → GitHub OAuth connection must be authorised manually in the Cloudflare dashboard before first apply (Workers & Pages → Settings → Integrations → GitHub). Terraform cannot create it.

--- a/docs/github-repos.md
+++ b/docs/github-repos.md
@@ -1,0 +1,122 @@
+# GitHub Repository Management
+
+Relevant stack: `tf/infra/singletons/`
+
+---
+
+## Overview
+
+GitHub repository configuration is managed in `tf/infra/singletons/`:
+
+| File | What it manages |
+|---|---|
+| `github_repos.tf` | Repository creation and settings |
+| `github_labels.tf` | Issue labels (standard + custom per repo) |
+| `github_secrets.tf` | GitHub Actions secrets |
+
+Provider: `integrations/github` v6.4.0, configured with `owner = "gpo"`.
+
+---
+
+## Existing repositories
+
+| Repo | Visibility | Description |
+|---|---|---|
+| `secure-gpo-ca` | private | Drupal/CiviCRM site |
+| `gpo-ca` | private | Main GPO website |
+| `gpo-platform-configs` | public | This repo |
+| `gpo-it` | private | Google Workspace config |
+| `civicrm-api` | public | JS/TS CiviCRM client |
+| `public` | public | READMEs and roadmap |
+| `open-walk-sheets` | public | Walk sheets with wiki |
+| `.github` | public | Org-wide settings |
+| `migrate_bitbucket_to_github` | public | Migration tooling |
+| `CDNTaxReceipts` | public | Tax receipt tooling |
+
+---
+
+## Adding a new repository
+
+Add to `tf/infra/singletons/github_repos.tf`. Pattern from existing repos:
+
+```hcl
+resource "github_repository" "my_new_repo" {
+  name        = "my-new-repo"
+  description = "What this repo is for"
+  visibility  = "private"  # or "public"
+
+  # Branch settings
+  auto_init          = true
+  default_branch     = "main"  # set via github_branch_default below
+
+  # Merge strategy (choose what fits the team workflow)
+  allow_merge_commit     = false
+  allow_squash_merge     = true
+  allow_rebase_merge     = false
+  delete_branch_on_merge = true
+
+  vulnerability_alerts = true
+}
+
+resource "github_branch_default" "my_new_repo" {
+  repository = github_repository.my_new_repo.name
+  branch     = "main"
+}
+```
+
+---
+
+## Adding issue labels
+
+Labels are managed via the `github_default_labels` module in `tf/infra/singletons/github_labels.tf`.
+
+**To apply standard labels only:**
+```hcl
+module "my_repo_labels" {
+  source     = "../../modules/infra/github_default_labels"
+  repository = github_repository.my_new_repo.name
+  labels     = []
+}
+```
+
+**To add custom labels on top of the standard set:**
+```hcl
+module "my_repo_labels" {
+  source     = "../../modules/infra/github_default_labels"
+  repository = github_repository.my_new_repo.name
+  labels = [
+    { name = "CiviCRM",  description = "CiviCRM related", color = "e4e669" },
+    { name = "Drupal",   description = "Drupal related",  color = "1d76db" },
+  ]
+}
+```
+
+Standard labels created by the module include: Epic, enhancement, performance, bug, documentation, question, invalid, wontfix, duplicate, help wanted, good first issue, volunteer.
+
+---
+
+## Adding GitHub Actions secrets
+
+Secrets are defined in `tf/infra/singletons/github_secrets.tf`. Values come from the SOPS-encrypted `secrets.env` file.
+
+```hcl
+resource "github_actions_secret" "my_repo_my_secret" {
+  repository      = github_repository.my_new_repo.name
+  secret_name     = "MY_SECRET_NAME"
+  plaintext_value = data.sops_file.secrets.data["my_secret_key"]
+}
+```
+
+The SOPS key name (`my_secret_key`) must exist in `secrets.env`. See [docs/secrets-and-sops.md](secrets-and-sops.md) for how to add a new secret.
+
+---
+
+## Secrets currently managed
+
+Both `gpo-ca` and `secure-gpo-ca` have these Actions secrets set:
+
+- `SSH_USER`
+- `SSH_HOST_STAGE`
+- `SSH_HOST_PROD`
+- `SSH_PRIVATE_KEY`
+- `SSH_PUBLIC_KEY`

--- a/docs/github-repos.md
+++ b/docs/github-repos.md
@@ -1,122 +1,28 @@
-# GitHub Repository Management
+# GitHub Repos
 
-Relevant stack: `tf/infra/singletons/`
+File: `tf/infra/singletons/github_repos.tf`
+Labels: `tf/infra/singletons/github_labels.tf`
+Secrets: `tf/infra/singletons/github_secrets.tf`
 
----
+## Repos managed
 
-## Overview
-
-GitHub repository configuration is managed in `tf/infra/singletons/`:
-
-| File | What it manages |
+| Repo | Visibility |
 |---|---|
-| `github_repos.tf` | Repository creation and settings |
-| `github_labels.tf` | Issue labels (standard + custom per repo) |
-| `github_secrets.tf` | GitHub Actions secrets |
+| `secure-gpo-ca` | private |
+| `gpo-ca` | private |
+| `gpo-platform-configs` | public |
+| `gpo-it` | private |
+| `civicrm-api` | public |
+| `public` | public |
+| `open-walk-sheets` | public |
+| `.github` | public |
+| `migrate_bitbucket_to_github` | public |
+| `CDNTaxReceipts` | public |
 
-Provider: `integrations/github` v6.4.0, configured with `owner = "gpo"`.
+## Actions secrets
 
----
+Both `gpo-ca` and `secure-gpo-ca` have: `SSH_USER`, `SSH_HOST_STAGE`, `SSH_HOST_PROD`, `SSH_PRIVATE_KEY`, `SSH_PUBLIC_KEY` — all sourced from SOPS `secrets.env`.
 
-## Existing repositories
+## Labels
 
-| Repo | Visibility | Description |
-|---|---|---|
-| `secure-gpo-ca` | private | Drupal/CiviCRM site |
-| `gpo-ca` | private | Main GPO website |
-| `gpo-platform-configs` | public | This repo |
-| `gpo-it` | private | Google Workspace config |
-| `civicrm-api` | public | JS/TS CiviCRM client |
-| `public` | public | READMEs and roadmap |
-| `open-walk-sheets` | public | Walk sheets with wiki |
-| `.github` | public | Org-wide settings |
-| `migrate_bitbucket_to_github` | public | Migration tooling |
-| `CDNTaxReceipts` | public | Tax receipt tooling |
-
----
-
-## Adding a new repository
-
-Add to `tf/infra/singletons/github_repos.tf`. Pattern from existing repos:
-
-```hcl
-resource "github_repository" "my_new_repo" {
-  name        = "my-new-repo"
-  description = "What this repo is for"
-  visibility  = "private"  # or "public"
-
-  # Branch settings
-  auto_init          = true
-  default_branch     = "main"  # set via github_branch_default below
-
-  # Merge strategy (choose what fits the team workflow)
-  allow_merge_commit     = false
-  allow_squash_merge     = true
-  allow_rebase_merge     = false
-  delete_branch_on_merge = true
-
-  vulnerability_alerts = true
-}
-
-resource "github_branch_default" "my_new_repo" {
-  repository = github_repository.my_new_repo.name
-  branch     = "main"
-}
-```
-
----
-
-## Adding issue labels
-
-Labels are managed via the `github_default_labels` module in `tf/infra/singletons/github_labels.tf`.
-
-**To apply standard labels only:**
-```hcl
-module "my_repo_labels" {
-  source     = "../../modules/infra/github_default_labels"
-  repository = github_repository.my_new_repo.name
-  labels     = []
-}
-```
-
-**To add custom labels on top of the standard set:**
-```hcl
-module "my_repo_labels" {
-  source     = "../../modules/infra/github_default_labels"
-  repository = github_repository.my_new_repo.name
-  labels = [
-    { name = "CiviCRM",  description = "CiviCRM related", color = "e4e669" },
-    { name = "Drupal",   description = "Drupal related",  color = "1d76db" },
-  ]
-}
-```
-
-Standard labels created by the module include: Epic, enhancement, performance, bug, documentation, question, invalid, wontfix, duplicate, help wanted, good first issue, volunteer.
-
----
-
-## Adding GitHub Actions secrets
-
-Secrets are defined in `tf/infra/singletons/github_secrets.tf`. Values come from the SOPS-encrypted `secrets.env` file.
-
-```hcl
-resource "github_actions_secret" "my_repo_my_secret" {
-  repository      = github_repository.my_new_repo.name
-  secret_name     = "MY_SECRET_NAME"
-  plaintext_value = data.sops_file.secrets.data["my_secret_key"]
-}
-```
-
-The SOPS key name (`my_secret_key`) must exist in `secrets.env`. See [docs/secrets-and-sops.md](secrets-and-sops.md) for how to add a new secret.
-
----
-
-## Secrets currently managed
-
-Both `gpo-ca` and `secure-gpo-ca` have these Actions secrets set:
-
-- `SSH_USER`
-- `SSH_HOST_STAGE`
-- `SSH_HOST_PROD`
-- `SSH_PRIVATE_KEY`
-- `SSH_PUBLIC_KEY`
+Standard labels applied via `tf/modules/infra/github_default_labels`. Custom labels (e.g. CiviCRM, Drupal) added per-repo as overrides.

--- a/docs/gke-and-gcp.md
+++ b/docs/gke-and-gcp.md
@@ -1,135 +1,29 @@
-# GKE and GCP Infrastructure
+# GKE and GCP
 
-Relevant stacks: `tf/infra/prod/`, `tf/infra/stage/`
-Relevant modules: `tf/modules/infra/gcp/gke/`, `tf/modules/infra/gcp/gar/`
+Modules: `tf/modules/infra/gcp/gke/`, `tf/modules/infra/gcp/gar/`
+Instantiated in: `tf/infra/prod/main.tf`, `tf/infra/stage/main.tf`
 
----
+## GCP projects (per environment)
 
-## GCP projects
-
-Two GCP projects per environment, created in the `bootstrap` stack:
-
-| Project | Environment | Purpose |
-|---|---|---|
-| `gpo-data-prod` | prod | Data infrastructure (BigQuery, etc.) |
-| `gpo-eng-prod` | prod | Engineering infrastructure (GKE, GAR) |
-| `calm-segment-466901-e4` | stage | Data (stage) |
-| `gpo-eng-stage` | stage | Engineering (stage) |
-
-GCP org ID: `267619224561`
-GCP billing account: `019C4D-E56387-A59CAF`
-
----
-
-## GKE cluster
-
-One GKE cluster per environment, defined in `tf/infra/{prod,stage}/main.tf` via the `gke` module:
-
-```
-tf/modules/infra/gcp/gke/
-```
-
-### What the module creates
-
-- GCP VPC network: `gpo-prod` / `gpo-stage` (auto-create subnetworks)
-- GCP service account: `gke-gpo-prod` / `gke-gpo-stage`
-- GKE cluster (`google_container_cluster`):
-  - Initial node count: 3
-  - Gateway API: `CHANNEL_STANDARD` (no separate ingress controller needed)
-  - Workload Identity enabled
-  - GKE Metadata Server enabled
-  - Deletion protection: off
-- Global static external IP: `gke-ingress-ip` (used for DNS A records in the app layer)
-
-### Key design decisions
-
-- **Gateway API** is used instead of a separately-deployed ingress controller (see `DECISION_LOG.md`)
-- **Workload Identity** is enabled so K8s service accounts can authenticate to GCP APIs without key files
-- The static IP is reserved at the infra layer and passed as an output to the app layer
-
-### Module inputs
-
-```hcl
-module "gke" {
-  source      = "../../modules/infra/gcp/gke"
-  name        = local.name         # "gpo"
-  environment = local.environment  # "prod" or "stage"
-  location    = local.zone_toronto # "northamerica-northeast2-a"
-}
-```
-
-### Output used by app layer
-
-```hcl
-output "gke_ingress_ip" {
-  value = module.gke.ingress_ip
-}
-```
-
-This IP is read by `tf/app/{prod,stage}/` via remote state and passed into app modules as `ingress_ip_address`.
-
----
-
-## Artifact Registry (GAR)
-
-One Docker registry per environment, defined in `tf/infra/{prod,stage}/main.tf` via the `gar` module:
-
-```
-tf/modules/infra/gcp/gar/
-```
-
-### What the module creates
-
-- Enables `artifactregistry.googleapis.com`
-- Creates a Docker repository named `gpo` in `northamerica-northeast2` (Toronto)
-- Full URI: `northamerica-northeast2-docker.pkg.dev/<project>/gpo`
-
-### Output used by app layer
-
-```hcl
-output "image_repository_uri" {
-  value = module.gar.repository_uri
-}
-```
-
----
-
-## Region and zone
-
-| Variable | Value |
+| Project ID | Purpose |
 |---|---|
-| `region_toronto` | `northamerica-northeast2` |
-| `zone_toronto` | `northamerica-northeast2-a` |
+| `gpo-eng-prod` / `gpo-eng-stage` | GKE cluster, Artifact Registry |
+| `gpo-data-prod` / `calm-segment-466901-e4` | BigQuery, data infra |
 
-All GCP resources are deployed to Toronto. Stage uses the same region.
+Org: `267619224561` · Billing: `019C4D-E56387-A59CAF`
+Project IDs come from bootstrap remote state — never hardcoded.
 
----
+## Region / zone
 
-## GCP provider configuration
+`northamerica-northeast2` (Toronto), zone `northamerica-northeast2-a`. Used for all GCP resources.
 
-The `infra/prod` stack uses two Google provider aliases:
+## What the modules create
 
-```hcl
-provider "google" {
-  alias   = "gpo_eng"
-  project = data.terraform_remote_state.bootstrap.outputs.gcp_project_gpo_eng.project_id
-}
-```
+**gke**: VPC, node service account, GKE cluster (Gateway API enabled, Workload Identity enabled), global static IP `gke-ingress-ip`
+**gar**: Docker registry `gpo` at `northamerica-northeast2-docker.pkg.dev/<project>/gpo`
 
-The project ID is read from bootstrap remote state — never hardcoded.
+## Key outputs (consumed by app layer via remote state)
 
----
-
-## IAM for GKE nodes
-
-The GKE node service account is granted:
-- `roles/artifactregistry.reader` — pull images from GAR
-- `roles/container.defaultNodeServiceAccount` — standard GKE node permissions
-
-These are defined in `tf/modules/infra/gcp/gke/iam.tf`.
-
----
-
-## Enabling new GCP APIs
-
-APIs are enabled in `tf/modules/infra/gcp/gke/apis.tf` (for the GKE module) and `tf/modules/bootstrap/apis/main.tf` (for bootstrap). To enable an additional API, add a `google_project_service` resource with `disable_on_destroy = false`.
+- `gke_ingress_ip` — static IP used for all app DNS A records
+- `image_repository_uri` — GAR registry URI
+- `cloudflare_zone_gpo_tools` — `{ id, zone }` passed to app modules

--- a/docs/gke-and-gcp.md
+++ b/docs/gke-and-gcp.md
@@ -1,0 +1,135 @@
+# GKE and GCP Infrastructure
+
+Relevant stacks: `tf/infra/prod/`, `tf/infra/stage/`
+Relevant modules: `tf/modules/infra/gcp/gke/`, `tf/modules/infra/gcp/gar/`
+
+---
+
+## GCP projects
+
+Two GCP projects per environment, created in the `bootstrap` stack:
+
+| Project | Environment | Purpose |
+|---|---|---|
+| `gpo-data-prod` | prod | Data infrastructure (BigQuery, etc.) |
+| `gpo-eng-prod` | prod | Engineering infrastructure (GKE, GAR) |
+| `calm-segment-466901-e4` | stage | Data (stage) |
+| `gpo-eng-stage` | stage | Engineering (stage) |
+
+GCP org ID: `267619224561`
+GCP billing account: `019C4D-E56387-A59CAF`
+
+---
+
+## GKE cluster
+
+One GKE cluster per environment, defined in `tf/infra/{prod,stage}/main.tf` via the `gke` module:
+
+```
+tf/modules/infra/gcp/gke/
+```
+
+### What the module creates
+
+- GCP VPC network: `gpo-prod` / `gpo-stage` (auto-create subnetworks)
+- GCP service account: `gke-gpo-prod` / `gke-gpo-stage`
+- GKE cluster (`google_container_cluster`):
+  - Initial node count: 3
+  - Gateway API: `CHANNEL_STANDARD` (no separate ingress controller needed)
+  - Workload Identity enabled
+  - GKE Metadata Server enabled
+  - Deletion protection: off
+- Global static external IP: `gke-ingress-ip` (used for DNS A records in the app layer)
+
+### Key design decisions
+
+- **Gateway API** is used instead of a separately-deployed ingress controller (see `DECISION_LOG.md`)
+- **Workload Identity** is enabled so K8s service accounts can authenticate to GCP APIs without key files
+- The static IP is reserved at the infra layer and passed as an output to the app layer
+
+### Module inputs
+
+```hcl
+module "gke" {
+  source      = "../../modules/infra/gcp/gke"
+  name        = local.name         # "gpo"
+  environment = local.environment  # "prod" or "stage"
+  location    = local.zone_toronto # "northamerica-northeast2-a"
+}
+```
+
+### Output used by app layer
+
+```hcl
+output "gke_ingress_ip" {
+  value = module.gke.ingress_ip
+}
+```
+
+This IP is read by `tf/app/{prod,stage}/` via remote state and passed into app modules as `ingress_ip_address`.
+
+---
+
+## Artifact Registry (GAR)
+
+One Docker registry per environment, defined in `tf/infra/{prod,stage}/main.tf` via the `gar` module:
+
+```
+tf/modules/infra/gcp/gar/
+```
+
+### What the module creates
+
+- Enables `artifactregistry.googleapis.com`
+- Creates a Docker repository named `gpo` in `northamerica-northeast2` (Toronto)
+- Full URI: `northamerica-northeast2-docker.pkg.dev/<project>/gpo`
+
+### Output used by app layer
+
+```hcl
+output "image_repository_uri" {
+  value = module.gar.repository_uri
+}
+```
+
+---
+
+## Region and zone
+
+| Variable | Value |
+|---|---|
+| `region_toronto` | `northamerica-northeast2` |
+| `zone_toronto` | `northamerica-northeast2-a` |
+
+All GCP resources are deployed to Toronto. Stage uses the same region.
+
+---
+
+## GCP provider configuration
+
+The `infra/prod` stack uses two Google provider aliases:
+
+```hcl
+provider "google" {
+  alias   = "gpo_eng"
+  project = data.terraform_remote_state.bootstrap.outputs.gcp_project_gpo_eng.project_id
+}
+```
+
+The project ID is read from bootstrap remote state — never hardcoded.
+
+---
+
+## IAM for GKE nodes
+
+The GKE node service account is granted:
+- `roles/artifactregistry.reader` — pull images from GAR
+- `roles/container.defaultNodeServiceAccount` — standard GKE node permissions
+
+These are defined in `tf/modules/infra/gcp/gke/iam.tf`.
+
+---
+
+## Enabling new GCP APIs
+
+APIs are enabled in `tf/modules/infra/gcp/gke/apis.tf` (for the GKE module) and `tf/modules/bootstrap/apis/main.tf` (for bootstrap). To enable an additional API, add a `google_project_service` resource with `disable_on_destroy = false`.

--- a/docs/iam-users.md
+++ b/docs/iam-users.md
@@ -1,0 +1,81 @@
+# IAM Users
+
+Relevant stack: `tf/bootstrap/{prod,stage}/`
+Relevant module: `tf/modules/bootstrap/iam_users/`
+
+---
+
+## AWS IAM users
+
+### Existing users
+
+Users are defined in `tf/bootstrap/{prod,stage}/locals.tf`:
+
+```hcl
+# prod and stage both have:
+iam_admin_users = ["rsalmond", "ianedington"]
+
+# stage also has:
+iam_admin_users = ["rsalmond", "ianedington", "verdird", "mattw"]
+iam_eks_users   = ["pnovikov"]
+```
+
+### User types
+
+| Type | Group | Permissions |
+|---|---|---|
+| `iam_admin_users` | `admin` | `AdministratorAccess` |
+| `iam_eks_users` | `eks` | `ReadOnlyAccess` + ECR push + KMS decrypt (stage only) |
+
+### Adding a new admin user
+
+1. Add the username to `iam_admin_users` in `tf/bootstrap/{prod,stage}/locals.tf`
+2. Run `tofu apply` in `tf/bootstrap/prod/` and/or `tf/bootstrap/stage/`
+3. Retrieve the temporary password:
+   ```bash
+   tofu output -json | jq '.user_creds.value'
+   ```
+   The user must change their password on first login.
+
+### Adding a new EKS user
+
+Add the username to `iam_eks_users` in the relevant `locals.tf`. EKS users are also granted EKS access entries in the `eks` module — their ARN is passed from bootstrap outputs through to the infra stack automatically via remote state.
+
+---
+
+## GCP developer access (stage only)
+
+Module: `tf/modules/bootstrap/gcp_iam_devs_stage/`
+
+Stage supports granting GCP access to individual developer email addresses. This is defined in `tf/bootstrap/stage/main.tf`:
+
+```hcl
+module "gcp_iam_dev_<username>" {
+  source  = "../../modules/bootstrap/gcp_iam_devs_stage"
+  project = module.apis.project  # or relevant project
+  user    = "developer@example.com"
+}
+```
+
+The module grants:
+- `roles/artifactregistry.writer` — push Docker images to GAR
+- `roles/container.developer` — access GKE clusters (no create/delete)
+
+### Adding a new developer (stage)
+
+1. Add their email to `local.dev_users` in `tf/bootstrap/stage/locals.tf`:
+   ```hcl
+   dev_users = ["existing@example.com", "newdev@example.com"]
+   ```
+2. The `main.tf` iterates over this list with `for_each = toset(local.dev_users)` — no other changes needed.
+3. Run `tofu apply` in `tf/bootstrap/stage/`.
+
+---
+
+## DigitalOcean monitoring user
+
+There is one additional IAM user not managed through the `iam_users` module: `digital-ocean-monitoring`.
+
+This is created by the `legacy_logging` app module (`tf/modules/app/legacy_logging/`) and is used for shipping DigitalOcean logs to AWS CloudWatch. It has a custom IAM policy allowing CloudWatch and CloudWatch Logs write actions.
+
+This user is instantiated in `tf/app/{prod,stage}/main.tf` and its access key is output (sensitive) for use in the DigitalOcean monitoring configuration.

--- a/docs/iam-users.md
+++ b/docs/iam-users.md
@@ -1,81 +1,27 @@
 # IAM Users
 
-Relevant stack: `tf/bootstrap/{prod,stage}/`
-Relevant module: `tf/modules/bootstrap/iam_users/`
+## AWS — `tf/modules/bootstrap/iam_users/`
 
----
+Defined in `tf/bootstrap/{prod,stage}/locals.tf`:
 
-## AWS IAM users
-
-### Existing users
-
-Users are defined in `tf/bootstrap/{prod,stage}/locals.tf`:
-
-```hcl
-# prod and stage both have:
-iam_admin_users = ["rsalmond", "ianedington"]
-
-# stage also has:
-iam_admin_users = ["rsalmond", "ianedington", "verdird", "mattw"]
-iam_eks_users   = ["pnovikov"]
+```
+iam_admin_users = ["rsalmond", "ianedington"]          # prod + stage
+iam_admin_users = ["rsalmond", "ianedington", "verdird", "mattw"]  # stage also has these
+iam_eks_users   = ["pnovikov"]                          # stage only
 ```
 
-### User types
+- Admin users → `admin` group → `AdministratorAccess`
+- EKS users → `eks` group → scoped read/ECR/KMS access (stage only)
 
-| Type | Group | Permissions |
-|---|---|---|
-| `iam_admin_users` | `admin` | `AdministratorAccess` |
-| `iam_eks_users` | `eks` | `ReadOnlyAccess` + ECR push + KMS decrypt (stage only) |
+Initial passwords retrieved via `tofu output -json | jq '.user_creds.value'` after first apply.
 
-### Adding a new admin user
-
-1. Add the username to `iam_admin_users` in `tf/bootstrap/{prod,stage}/locals.tf`
-2. Run `tofu apply` in `tf/bootstrap/prod/` and/or `tf/bootstrap/stage/`
-3. Retrieve the temporary password:
-   ```bash
-   tofu output -json | jq '.user_creds.value'
-   ```
-   The user must change their password on first login.
-
-### Adding a new EKS user
-
-Add the username to `iam_eks_users` in the relevant `locals.tf`. EKS users are also granted EKS access entries in the `eks` module — their ARN is passed from bootstrap outputs through to the infra stack automatically via remote state.
-
----
-
-## GCP developer access (stage only)
+## GCP developer access — stage only
 
 Module: `tf/modules/bootstrap/gcp_iam_devs_stage/`
+Defined in: `tf/bootstrap/stage/locals.tf` → `dev_users = [...]`
 
-Stage supports granting GCP access to individual developer email addresses. This is defined in `tf/bootstrap/stage/main.tf`:
-
-```hcl
-module "gcp_iam_dev_<username>" {
-  source  = "../../modules/bootstrap/gcp_iam_devs_stage"
-  project = module.apis.project  # or relevant project
-  user    = "developer@example.com"
-}
-```
-
-The module grants:
-- `roles/artifactregistry.writer` — push Docker images to GAR
-- `roles/container.developer` — access GKE clusters (no create/delete)
-
-### Adding a new developer (stage)
-
-1. Add their email to `local.dev_users` in `tf/bootstrap/stage/locals.tf`:
-   ```hcl
-   dev_users = ["existing@example.com", "newdev@example.com"]
-   ```
-2. The `main.tf` iterates over this list with `for_each = toset(local.dev_users)` — no other changes needed.
-3. Run `tofu apply` in `tf/bootstrap/stage/`.
-
----
+Grants `roles/artifactregistry.writer` + `roles/container.developer`. Add an email to `dev_users` and apply.
 
 ## DigitalOcean monitoring user
 
-There is one additional IAM user not managed through the `iam_users` module: `digital-ocean-monitoring`.
-
-This is created by the `legacy_logging` app module (`tf/modules/app/legacy_logging/`) and is used for shipping DigitalOcean logs to AWS CloudWatch. It has a custom IAM policy allowing CloudWatch and CloudWatch Logs write actions.
-
-This user is instantiated in `tf/app/{prod,stage}/main.tf` and its access key is output (sensitive) for use in the DigitalOcean monitoring configuration.
+Created by `tf/modules/app/legacy_logging/` — IAM user `digital-ocean-monitoring` with a CloudWatch write policy. Not in the `iam_users` module.

--- a/docs/secrets-and-sops.md
+++ b/docs/secrets-and-sops.md
@@ -1,0 +1,110 @@
+# Secrets and SOPS
+
+---
+
+## Overview
+
+All secrets are encrypted with [SOPS](https://github.com/getsops/sops) using KMS keys (both AWS and GCP). Encrypted files are committed to the repository. Plain text secrets are **never** committed.
+
+---
+
+## Secret files
+
+| File | Scope |
+|---|---|
+| `secrets.env` | Shared across all stacks and environments |
+| `secrets.prod.env` | Production-only secrets |
+| `secrets.stage.env` | Stage-only secrets |
+
+All files live at the **repository root**.
+
+---
+
+## How secrets are consumed in Terraform
+
+Each stack declares a SOPS data source pointing at the relevant secrets file:
+
+```hcl
+data "sops_file" "secrets" {
+  source_file = "../../secrets.env"   # path relative to the .tf file
+}
+```
+
+Values are accessed by key:
+```hcl
+api_key    = data.sops_file.secrets.data["cloudflare_api_key"]
+account_id = data.sops_file.secrets.data["cloudflare_account_id"]
+```
+
+Stacks that need both shared and environment-specific secrets declare two data sources:
+```hcl
+data "sops_file" "secrets"      { source_file = "../../secrets.env" }
+data "sops_file" "secrets_prod" { source_file = "../../secrets.prod.env" }
+```
+
+---
+
+## Known secret keys (shared secrets.env)
+
+| Key | Used by |
+|---|---|
+| `cloudflare_api_key` | All Cloudflare resources |
+| `cloudflare_account_id` | Cloudflare zone creation, Pages projects |
+| `github_ssh_user` | GitHub Actions secrets |
+| `github_ssh_host_stage` | GitHub Actions secrets |
+| `github_ssh_host_prod` | GitHub Actions secrets |
+| `github_ssh_private_key` | GitHub Actions secrets |
+| `github_ssh_public_key` | GitHub Actions secrets |
+
+---
+
+## Adding a new secret
+
+1. **Decrypt** the relevant secrets file:
+   ```bash
+   sops --decrypt secrets.env > secrets.env.dec
+   ```
+2. **Add** your new key/value to the decrypted file.
+3. **Re-encrypt**:
+   ```bash
+   sops --encrypt secrets.env.dec > secrets.env
+   rm secrets.env.dec
+   ```
+4. **Reference** it in your Terraform:
+   ```hcl
+   my_value = data.sops_file.secrets.data["my_new_key"]
+   ```
+5. Commit the updated (encrypted) `secrets.env`.
+
+---
+
+## KMS keys
+
+SOPS uses both AWS KMS and GCP KMS keys for encryption (multi-key redundancy). Keys are created by the `sops` bootstrap module:
+
+- **AWS KMS**: one key per environment, created in `tf/modules/bootstrap/sops/main.tf`
+- **GCP KMS**: key ring `sops-{environment}` with crypto key `sops-{environment}`, created in `tf/modules/bootstrap/sops/gcp.tf`
+  - Lifecycle: `prevent_destroy = true` — these keys cannot be accidentally deleted via Terraform
+
+---
+
+## SOPS provider
+
+The `carlpett/sops` provider v0.7.2 is declared in every stack's `tofu.tf`:
+
+```hcl
+sops = {
+  source  = "carlpett/sops"
+  version = "0.7.2"
+}
+```
+
+No provider configuration block is needed — it reads from your current AWS/GCP credentials automatically.
+
+---
+
+## Rotating secrets
+
+1. Update the value in the secrets file (decrypt → edit → re-encrypt, as above).
+2. Run `tofu plan` in the affected stack — Terraform will detect the changed value.
+3. Run `tofu apply` to push the new value to any resources that reference it (e.g. GitHub Actions secrets).

--- a/docs/secrets-and-sops.md
+++ b/docs/secrets-and-sops.md
@@ -1,110 +1,28 @@
 # Secrets and SOPS
 
----
-
-## Overview
-
-All secrets are encrypted with [SOPS](https://github.com/getsops/sops) using KMS keys (both AWS and GCP). Encrypted files are committed to the repository. Plain text secrets are **never** committed.
-
----
-
-## Secret files
+## Files
 
 | File | Scope |
 |---|---|
-| `secrets.env` | Shared across all stacks and environments |
-| `secrets.prod.env` | Production-only secrets |
-| `secrets.stage.env` | Stage-only secrets |
+| `secrets.env` | All stacks |
+| `secrets.prod.env` | Production only |
+| `secrets.stage.env` | Stage only |
 
-All files live at the **repository root**.
+All at repo root, SOPS-encrypted, safe to commit.
 
----
-
-## How secrets are consumed in Terraform
-
-Each stack declares a SOPS data source pointing at the relevant secrets file:
+## Usage in Terraform
 
 ```hcl
 data "sops_file" "secrets" {
-  source_file = "../../secrets.env"   # path relative to the .tf file
+  source_file = "../../secrets.env"  # path relative to the .tf file
 }
+# Access: data.sops_file.secrets.data["key_name"]
 ```
 
-Values are accessed by key:
-```hcl
-api_key    = data.sops_file.secrets.data["cloudflare_api_key"]
-account_id = data.sops_file.secrets.data["cloudflare_account_id"]
-```
+## Known keys (secrets.env)
 
-Stacks that need both shared and environment-specific secrets declare two data sources:
-```hcl
-data "sops_file" "secrets"      { source_file = "../../secrets.env" }
-data "sops_file" "secrets_prod" { source_file = "../../secrets.prod.env" }
-```
-
----
-
-## Known secret keys (shared secrets.env)
-
-| Key | Used by |
-|---|---|
-| `cloudflare_api_key` | All Cloudflare resources |
-| `cloudflare_account_id` | Cloudflare zone creation, Pages projects |
-| `github_ssh_user` | GitHub Actions secrets |
-| `github_ssh_host_stage` | GitHub Actions secrets |
-| `github_ssh_host_prod` | GitHub Actions secrets |
-| `github_ssh_private_key` | GitHub Actions secrets |
-| `github_ssh_public_key` | GitHub Actions secrets |
-
----
-
-## Adding a new secret
-
-1. **Decrypt** the relevant secrets file:
-   ```bash
-   sops --decrypt secrets.env > secrets.env.dec
-   ```
-2. **Add** your new key/value to the decrypted file.
-3. **Re-encrypt**:
-   ```bash
-   sops --encrypt secrets.env.dec > secrets.env
-   rm secrets.env.dec
-   ```
-4. **Reference** it in your Terraform:
-   ```hcl
-   my_value = data.sops_file.secrets.data["my_new_key"]
-   ```
-5. Commit the updated (encrypted) `secrets.env`.
-
----
+`cloudflare_api_key`, `cloudflare_account_id`, `github_ssh_user`, `github_ssh_host_stage`, `github_ssh_host_prod`, `github_ssh_private_key`, `github_ssh_public_key`
 
 ## KMS keys
 
-SOPS uses both AWS KMS and GCP KMS keys for encryption (multi-key redundancy). Keys are created by the `sops` bootstrap module:
-
-- **AWS KMS**: one key per environment, created in `tf/modules/bootstrap/sops/main.tf`
-- **GCP KMS**: key ring `sops-{environment}` with crypto key `sops-{environment}`, created in `tf/modules/bootstrap/sops/gcp.tf`
-  - Lifecycle: `prevent_destroy = true` — these keys cannot be accidentally deleted via Terraform
-
----
-
-## SOPS provider
-
-The `carlpett/sops` provider v0.7.2 is declared in every stack's `tofu.tf`:
-
-```hcl
-sops = {
-  source  = "carlpett/sops"
-  version = "0.7.2"
-}
-```
-
-No provider configuration block is needed — it reads from your current AWS/GCP credentials automatically.
-
----
-
-## Rotating secrets
-
-1. Update the value in the secrets file (decrypt → edit → re-encrypt, as above).
-2. Run `tofu plan` in the affected stack — Terraform will detect the changed value.
-3. Run `tofu apply` to push the new value to any resources that reference it (e.g. GitHub Actions secrets).
+Created by `tf/modules/bootstrap/sops/`. One AWS KMS key + one GCP KMS key ring/crypto key per environment (`sops-prod`, `sops-stage`). Both have `prevent_destroy = true`.

--- a/docs/stacks-and-state.md
+++ b/docs/stacks-and-state.md
@@ -105,11 +105,6 @@ tofu plan
 tofu apply
 ```
 
-**Critical:** The `app/` stacks must be run with reduced parallelism to avoid GCP API rate limits:
-```bash
-tofu apply -parallelism=1
-```
-
 ---
 
 ## Running all stacks
@@ -117,7 +112,7 @@ tofu apply -parallelism=1
 Use the `tofu-all` helper at the repo root to run a command across every stack:
 ```bash
 ./tofu-all plan
-./tofu-all apply -parallelism=1
+./tofu-all apply
 ```
 
 ---

--- a/docs/stacks-and-state.md
+++ b/docs/stacks-and-state.md
@@ -1,0 +1,127 @@
+# Stacks and State
+
+---
+
+## What is a stack?
+
+A "stack" is an independently deployable Terraform root module with its own state file. Changes to one stack do not affect other stacks until they are explicitly applied. This repo has seven stacks:
+
+| Stack directory | GCS state prefix | Deployed how often |
+|---|---|---|
+| `tf/bootstrap/prod` | `prod/bootstrap` | Rarely (new accounts, new users) |
+| `tf/bootstrap/stage` | `stage/bootstrap` | Rarely |
+| `tf/infra/singletons` | `infra/singletons` | Occasionally (DNS, GitHub repos) |
+| `tf/infra/prod` | `prod/infra` | Occasionally (cluster changes) |
+| `tf/infra/stage` | `stage/infra` | Occasionally |
+| `tf/app/prod` | `prod/app` | Regularly (new apps, config changes) |
+| `tf/app/stage` | `stage/app` | Regularly |
+
+All state is stored in GCS bucket **`gpo-tf-state-data`**.
+
+---
+
+## Dependency chain
+
+Stacks depend on each other in one direction only:
+
+```
+bootstrap → infra → app
+```
+
+- `infra` reads outputs from `bootstrap` via remote state
+- `app` reads outputs from `infra` via remote state
+- `singletons` is independent (no remote state dependencies)
+
+**You must apply lower layers before higher layers** when setting up from scratch. For day-to-day changes this is rarely relevant — most changes are isolated within one stack.
+
+---
+
+## How remote state references work
+
+Outputs from one stack are consumed by another using `terraform_remote_state`:
+
+```hcl
+# In tf/app/prod/remote_state.tf
+data "terraform_remote_state" "infra" {
+  backend = "gcs"
+  config = {
+    bucket = "gpo-tf-state-data"
+    prefix = "prod/infra"
+  }
+}
+```
+
+Then used as:
+```hcl
+cloudflare_zone = data.terraform_remote_state.infra.outputs.cloudflare_zone_gpo_tools
+ingress_ip      = data.terraform_remote_state.infra.outputs.gke_ingress_ip
+```
+
+### What infra/prod exports
+
+| Output | Type | Used by |
+|---|---|---|
+| `cloudflare_zone_gpo_tools` | `{ id, zone }` | App modules for DNS records |
+| `gke_ingress_ip` | string | App modules for DNS A records |
+| `image_repository_uri` | string | App layer for container image paths |
+
+### What bootstrap/prod exports
+
+| Output | Used by |
+|---|---|
+| `admin_user_arns` | infra (EKS access entries) |
+| `eks_user_arns` | infra (EKS access entries) |
+| `gcp_project_gpo_eng` | infra (GKE provider project) |
+| `gcp_project_gpo_data` | infra (BigQuery, etc.) |
+| `gcp_project_bootstrap` | infra (bootstrap project ID) |
+
+---
+
+## GCS backend configuration
+
+Every stack declares a backend in its `tofu.tf`:
+
+```hcl
+terraform {
+  backend "gcs" {
+    bucket = "gpo-tf-state-data"
+    prefix = "prod/infra"   # unique per stack
+  }
+}
+```
+
+The GCS bucket was created by the `state_bucket` bootstrap module. There is no DynamoDB-style locking for GCS — GCS uses native object locking.
+
+> **Note:** A DynamoDB table `terraform-state-locks` also exists (created by `state_bucket`) but is used only for the AWS backend, not GCS.
+
+---
+
+## Running a stack
+
+```bash
+cd tf/<layer>/<environment>
+tofu init     # needed after provider changes or first checkout
+tofu plan
+tofu apply
+```
+
+**Critical:** The `app/` stacks must be run with reduced parallelism to avoid GCP API rate limits:
+```bash
+tofu apply -parallelism=1
+```
+
+---
+
+## Running all stacks
+
+Use the `tofu-all` helper at the repo root to run a command across every stack:
+```bash
+./tofu-all plan
+./tofu-all apply -parallelism=1
+```
+
+---
+
+## Singletons vs per-environment stacks
+
+`tf/infra/singletons/` is intentionally not split into prod/stage. Resources here (gpo.ca DNS, GitHub repos) exist once globally. There is no staging equivalent — be careful, changes apply immediately to production systems.

--- a/docs/stacks-and-state.md
+++ b/docs/stacks-and-state.md
@@ -1,122 +1,23 @@
 # Stacks and State
 
----
+GCS bucket: `gpo-tf-state-data`
 
-## What is a stack?
-
-A "stack" is an independently deployable Terraform root module with its own state file. Changes to one stack do not affect other stacks until they are explicitly applied. This repo has seven stacks:
-
-| Stack directory | GCS state prefix | Deployed how often |
-|---|---|---|
-| `tf/bootstrap/prod` | `prod/bootstrap` | Rarely (new accounts, new users) |
-| `tf/bootstrap/stage` | `stage/bootstrap` | Rarely |
-| `tf/infra/singletons` | `infra/singletons` | Occasionally (DNS, GitHub repos) |
-| `tf/infra/prod` | `prod/infra` | Occasionally (cluster changes) |
-| `tf/infra/stage` | `stage/infra` | Occasionally |
-| `tf/app/prod` | `prod/app` | Regularly (new apps, config changes) |
-| `tf/app/stage` | `stage/app` | Regularly |
-
-All state is stored in GCS bucket **`gpo-tf-state-data`**.
-
----
-
-## Dependency chain
-
-Stacks depend on each other in one direction only:
-
-```
-bootstrap → infra → app
-```
-
-- `infra` reads outputs from `bootstrap` via remote state
-- `app` reads outputs from `infra` via remote state
-- `singletons` is independent (no remote state dependencies)
-
-**You must apply lower layers before higher layers** when setting up from scratch. For day-to-day changes this is rarely relevant — most changes are isolated within one stack.
-
----
-
-## How remote state references work
-
-Outputs from one stack are consumed by another using `terraform_remote_state`:
-
-```hcl
-# In tf/app/prod/remote_state.tf
-data "terraform_remote_state" "infra" {
-  backend = "gcs"
-  config = {
-    bucket = "gpo-tf-state-data"
-    prefix = "prod/infra"
-  }
-}
-```
-
-Then used as:
-```hcl
-cloudflare_zone = data.terraform_remote_state.infra.outputs.cloudflare_zone_gpo_tools
-ingress_ip      = data.terraform_remote_state.infra.outputs.gke_ingress_ip
-```
-
-### What infra/prod exports
-
-| Output | Type | Used by |
-|---|---|---|
-| `cloudflare_zone_gpo_tools` | `{ id, zone }` | App modules for DNS records |
-| `gke_ingress_ip` | string | App modules for DNS A records |
-| `image_repository_uri` | string | App layer for container image paths |
-
-### What bootstrap/prod exports
-
-| Output | Used by |
+| Stack | GCS prefix |
 |---|---|
-| `admin_user_arns` | infra (EKS access entries) |
-| `eks_user_arns` | infra (EKS access entries) |
-| `gcp_project_gpo_eng` | infra (GKE provider project) |
-| `gcp_project_gpo_data` | infra (BigQuery, etc.) |
-| `gcp_project_bootstrap` | infra (bootstrap project ID) |
+| `tf/bootstrap/prod` | `prod/bootstrap` |
+| `tf/bootstrap/stage` | `stage/bootstrap` |
+| `tf/infra/singletons` | `infra/singletons` |
+| `tf/infra/prod` | `prod/infra` |
+| `tf/infra/stage` | `stage/infra` |
+| `tf/app/prod` | `prod/app` |
+| `tf/app/stage` | `stage/app` |
 
----
+Dependency order: `bootstrap` → `infra` → `app`. Singletons have no dependencies.
 
-## GCS backend configuration
+## Remote state pattern
 
-Every stack declares a backend in its `tofu.tf`:
+`app` reads from `infra`, `infra` reads from `bootstrap` — both via `data.terraform_remote_state`. See `tf/app/prod/remote_state.tf` and `tf/infra/prod/remote_state.tf` for the exact config.
 
-```hcl
-terraform {
-  backend "gcs" {
-    bucket = "gpo-tf-state-data"
-    prefix = "prod/infra"   # unique per stack
-  }
-}
-```
+## tofu-all
 
-The GCS bucket was created by the `state_bucket` bootstrap module. There is no DynamoDB-style locking for GCS — GCS uses native object locking.
-
-> **Note:** A DynamoDB table `terraform-state-locks` also exists (created by `state_bucket`) but is used only for the AWS backend, not GCS.
-
----
-
-## Running a stack
-
-```bash
-cd tf/<layer>/<environment>
-tofu init     # needed after provider changes or first checkout
-tofu plan
-tofu apply
-```
-
----
-
-## Running all stacks
-
-Use the `tofu-all` helper at the repo root to run a command across every stack:
-```bash
-./tofu-all plan
-./tofu-all apply
-```
-
----
-
-## Singletons vs per-environment stacks
-
-`tf/infra/singletons/` is intentionally not split into prod/stage. Resources here (gpo.ca DNS, GitHub repos) exist once globally. There is no staging equivalent — be careful, changes apply immediately to production systems.
+Repo root has a `tofu-all` helper script to run a command across all stacks at once.


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` at the repo root — read by every agent on every task. Covers architecture overview, stack layout, critical rules (parallelism, SOPS, AWS profiles), provider versions, naming conventions, and a table of contents.
- Adds `docs/` with 10 feature-scoped docs, each written so an agent doing a specific job needs to read only one file.

## Docs index

| File | When to read it |
|---|---|
| `docs/cloudflare-dns.md` | Adding/changing DNS records or zones |
| `docs/cloudflare-pages.md` | Deploying a Cloudflare Pages site |
| `docs/github-repos.md` | Creating or configuring GitHub repos, labels, secrets |
| `docs/gke-and-gcp.md` | GKE clusters, GCP projects, Artifact Registry |
| `docs/aws-eks.md` | EKS, VPC, ECR |
| `docs/secrets-and-sops.md` | Adding/rotating secrets, SOPS setup |
| `docs/iam-users.md` | Adding AWS IAM or GCP developer users |
| `docs/stacks-and-state.md` | Stack boundaries, remote state wiring, apply order |
| `docs/app-layer.md` | Adding a new application module |
| `docs/bootstrap.md` | One-time account bootstrapping |

## No functional changes

This PR is documentation only — no Terraform resources are added or modified.