### PR TITLE
chore: update Superset to 6.0.0 (prod) [superseded]

### DIFF
--- a/kubernetes/superset/prod/helmfile.yaml
+++ b/kubernetes/superset/prod/helmfile.yaml
@@ -1,12 +1,8 @@
 # +argocd:skip-file-rendering
-repositories:
-- name: superset
-  url: https://apache.github.io/superset/
-
 releases:
 - name: superset
   namespace: superset
   chart: superset/superset
-  version: 0.15.0
+  version: 0.15.5
   values:
   - values.yaml

--- a/kubernetes/superset/prod/rendered/superset.yaml
+++ b/kubernetes/superset/prod/rendered/superset.yaml
@@ -236,7 +236,7 @@ metadata:
   namespace: superset
   labels:
     app: superset
-    chart: superset-0.15.0
+    chart: superset-0.15.5
     release: superset
     heritage: Helm
 spec:
@@ -258,7 +258,7 @@ metadata:
   namespace: superset
   labels:
     app: superset-worker
-    chart: superset-0.15.0
+    chart: superset-0.15.5
     release: superset
     heritage: Helm
 spec:
@@ -270,9 +270,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/superset_config.py: 7f9396795bb0a5a1b02cf8a9994fdfdd62b97e479a8f3c2bb04d1f7d638d65fa
+        checksum/superset_config.py: 9cc3f4cbdf7110d2962b2101311d78ddaf502d6b4f4fcc8ef4b216567722799d
         checksum/superset_bootstrap.sh: dc9a47141051ced34960c313860a55e03eb48c1fa36a0ed25c03ad60cd3b5c48
-        checksum/connections: c3d3ce69117f3ced7a541d038ebb96b49ca06c3234928cb895f0b3941e3c3c19
+        checksum/connections: 9d7f9aa15a1c2500ba4c5049cb934e8f5860d207d2dd5764b3282a326bc46067
         checksum/extraConfigs: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
         checksum/extraSecrets: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
         checksum/extraSecretEnv: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
@@ -295,9 +295,12 @@ spec:
           image: apache/superset:dockerize
           imagePullPolicy: IfNotPresent
           name: wait-for-postgres-redis
+          resources:
+            limits:
+              memory: 256Mi
       containers:
         - name: superset
-          image: northamerica-northeast2-docker.pkg.dev/gpo-eng-prod/gpo/apache-superset:v0.0.1
+          image: northamerica-northeast2-docker.pkg.dev/gpo-eng-prod/gpo/apache-superset:v0.0.2
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -338,7 +341,7 @@ metadata:
   namespace: superset
   labels:
     app: superset
-    chart: superset-0.15.0
+    chart: superset-0.15.5
     release: superset
     heritage: Helm
 spec:
@@ -351,10 +354,10 @@ spec:
     metadata:
       annotations:
         # Force reload on config changes
-        checksum/superset_config.py: 7f9396795bb0a5a1b02cf8a9994fdfdd62b97e479a8f3c2bb04d1f7d638d65fa
+        checksum/superset_config.py: 9cc3f4cbdf7110d2962b2101311d78ddaf502d6b4f4fcc8ef4b216567722799d
         checksum/superset_init.sh: e6b1e8eac1f7a79a07a6c72a0e2ee6e09654eeb439c6bbe61bfd676917c41e02
         checksum/superset_bootstrap.sh: dc9a47141051ced34960c313860a55e03eb48c1fa36a0ed25c03ad60cd3b5c48
-        checksum/connections: c3d3ce69117f3ced7a541d038ebb96b49ca06c3234928cb895f0b3941e3c3c19
+        checksum/connections: 9d7f9aa15a1c2500ba4c5049cb934e8f5860d207d2dd5764b3282a326bc46067
         checksum/extraConfigs: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
         checksum/extraSecrets: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
         checksum/extraSecretEnv: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
@@ -377,9 +380,12 @@ spec:
           image: apache/superset:dockerize
           imagePullPolicy: IfNotPresent
           name: wait-for-postgres
+          resources:
+            limits:
+              memory: 256Mi
       containers:
         - name: superset
-          image: northamerica-northeast2-docker.pkg.dev/gpo-eng-prod/gpo/apache-superset:v0.0.1
+          image: northamerica-northeast2-docker.pkg.dev/gpo-eng-prod/gpo/apache-superset:v0.0.2
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -576,7 +582,7 @@ metadata:
   namespace: superset
   labels:
     app: superset
-    chart: superset-0.15.0
+    chart: superset-0.15.5
     release: superset
     heritage: Helm
   annotations:
@@ -600,9 +606,12 @@ spec:
           image: apache/superset:dockerize
           imagePullPolicy: IfNotPresent
           name: wait-for-postgres
+          resources:
+            limits:
+              memory: 256Mi
       containers:
         - name: superset-init-db
-          image: northamerica-northeast2-docker.pkg.dev/gpo-eng-prod/gpo/apache-superset:v0.0.1
+          image: northamerica-northeast2-docker.pkg.dev/gpo-eng-prod/gpo/apache-superset:v0.0.2
           envFrom:
             - secretRef:
                 name: superset-env

--- a/kubernetes/superset/prod/values.yaml
+++ b/kubernetes/superset/prod/values.yaml
@@ -18,7 +18,7 @@ redis:
 # for MySQL and PostgreSQL drivers.
 image:
   repository: northamerica-northeast2-docker.pkg.dev/gpo-eng-prod/gpo/apache-superset
-  tag: v0.0.1
+  tag: v0.0.2
 # Enabling feature flags. Note this is Python code injected into config.py.
 # See https://github.com/apache/superset/blob/master/RESOURCES/FEATURE_FLAGS.md
 # and https://github.com/apache/superset/tree/master/helm/superset#values for

--- a/kubernetes/superset/prod/values.yaml
+++ b/kubernetes/superset/prod/values.yaml
@@ -7,6 +7,52 @@ supersetNode:
   connections:
     # default hostname provided by cnpg
     db_host: superset-rw
+  initContainers:
+    - name: wait-for-postgres
+      image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
+      imagePullPolicy: "{{ .Values.initImage.pullPolicy }}"
+      envFrom:
+        - secretRef:
+            name: "{{ tpl .Values.envFromSecret . }}"
+      command:
+        - /bin/sh
+        - -c
+        - dockerize -wait "tcp://$DB_HOST:$DB_PORT" -timeout 120s
+      resources:
+        limits:
+          memory: "256Mi"
+
+supersetWorker:
+  initContainers:
+    - name: wait-for-postgres-redis
+      image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
+      imagePullPolicy: "{{ .Values.initImage.pullPolicy }}"
+      envFrom:
+        - secretRef:
+            name: "{{ tpl .Values.envFromSecret . }}"
+      command:
+        - /bin/sh
+        - -c
+        - dockerize -wait "tcp://$DB_HOST:$DB_PORT" -wait "tcp://$REDIS_HOST:$REDIS_PORT" -timeout 120s
+      resources:
+        limits:
+          memory: "256Mi"
+
+init:
+  initContainers:
+    - name: wait-for-postgres
+      image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
+      imagePullPolicy: "{{ .Values.initImage.pullPolicy }}"
+      envFrom:
+        - secretRef:
+            name: "{{ tpl .Values.envFromSecret . }}"
+      command:
+        - /bin/sh
+        - -c
+        - dockerize -wait "tcp://$DB_HOST:$DB_PORT" -timeout 120s
+      resources:
+        limits:
+          memory: "256Mi"
 
 redis:
   image:


### PR DESCRIPTION
Upgrades Apache Superset to 6.0.0 on **prod**. Merge only after the stage PR is verified.

## Changes

- Upgrade Helm chart `superset/superset` from `0.15.0` → `0.15.5`
- Custom image tag `v0.0.2` (built on 6.0.0 base, adds mysqlclient + psycopg2-binary)
- Remove `repositories:` block from helmfile
- Remove CPU/memory `requests` from init containers — keep only `limits.memory: 256Mi`

## Test plan

- [ ] Stage PR (#stage) merged and verified
- [ ] Docker image `v0.0.2` pushed to `northamerica-northeast2-docker.pkg.dev/gpo-eng-prod/gpo/apache-superset`
- [ ] ArgoCD syncs prod successfully
- [ ] Superset UI loads and dashboards render correctly on prod

Supersedes #181

https://claude.ai/code/session_01R3G7PnRLXHyanWGGZetxwJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3G7PnRLXHyanWGGZetxwJ)_