### PR TITLE
Add Brevo DNS records for gpo.ca domain authentication

### DIFF
--- a/tf/infra/singletons/cloudflare_domains.tf
+++ b/tf/infra/singletons/cloudflare_domains.tf
@@ -381,3 +381,27 @@ resource "cloudflare_record" "facebook_secure_gpo_ca" {
   type    = "TXT"
   ttl     = 300
 }
+
+resource "cloudflare_record" "brevo1__domainkey_gpo_ca" {
+  zone_id = cloudflare_zone.gpo_ca.id
+  name    = "brevo1._domainkey.gpo.ca"
+  content = "b1.gpo-ca.dkim.brevo.com"
+  type    = "CNAME"
+  ttl     = 300
+}
+
+resource "cloudflare_record" "brevo2__domainkey_gpo_ca" {
+  zone_id = cloudflare_zone.gpo_ca.id
+  name    = "brevo2._domainkey.gpo.ca"
+  content = "b2.gpo-ca.dkim.brevo.com"
+  type    = "CNAME"
+  ttl     = 300
+}
+
+resource "cloudflare_record" "brevo_code_gpo_ca" {
+  zone_id = cloudflare_zone.gpo_ca.id
+  name    = "gpo.ca"
+  content = "brevo-code:fd451e5873e98d8026c77d5adab32379"
+  type    = "TXT"
+  ttl     = 300
+}


### PR DESCRIPTION
## Summary

- Adds two DKIM CNAME records (`brevo1._domainkey.gpo.ca`, `brevo2._domainkey.gpo.ca`) pointing to Brevo's DKIM servers
- Adds a `BREVO_CODE` TXT record on the root `gpo.ca` zone for domain ownership verification

## Test plan

- [ ] `tofu plan` in `tf/infra/singletons` shows 3 new records, no unexpected changes
- [ ] Verify in Brevo after apply

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACsbgJSyRjtU6Qmg1fH3oJ)_