### PR TITLE
Enable preview deployments for islandgetaway Pages project

### DIFF
--- a/tf/infra/singletons/cloudflare_islandgetaway.tf
+++ b/tf/infra/singletons/cloudflare_islandgetaway.tf
@@ -26,7 +26,7 @@ resource "cloudflare_pages_project" "islandgetaway" {
       pr_comments_enabled           = true
       deployments_enabled           = true
       production_deployment_enabled = true
-      preview_deployment_setting    = "none"
+      preview_deployment_setting    = "all"
     }
   }
 


### PR DESCRIPTION
## Summary

- Changes `preview_deployment_setting` from `"none"` to `"all"` in the `cloudflare_pages_project.islandgetaway` resource
- This enables Cloudflare to deploy a preview for every non-`main` branch push and post a PR comment with the preview URL

## Why this works

The Pages project was already Git-connected with `pr_comments_enabled = true` and `deployments_enabled = true` — the only thing blocking PR previews was `preview_deployment_setting = "none"`.

## After applying

Push any branch to `gpo/islandgetaway` (e.g. `claude/trusting-galileo-TNnyP`) and expect:
- A deployment status on the commit within ~60s
- A PR comment from the Cloudflare Workers and Pages bot with the preview URL (`https://<branch>.islandgetaway-ca.pages.dev`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TsN1kXhNerB1xXDBG29YHB)_