### PR TITLE
Enable Pages previews and gate them behind Cloudflare Access

### DIFF
--- a/tf/infra/singletons/cloudflare_access.tf
+++ b/tf/infra/singletons/cloudflare_access.tf
@@ -1,14 +1,3 @@
-# Cloudflare Zero Trust organisation — account-level singleton.
-# Must exist before any Access applications can be created.
-# The auth_domain becomes <team>.cloudflareaccess.com.
-resource "cloudflare_zero_trust_organization" "gpo" {
-  account_id                         = data.sops_file.secrets.data["cloudflare_account_id"]
-  name                               = "GPO"
-  auth_domain                        = "gpo"
-  is_ui_read_only                    = false
-  user_seat_expiration_inactive_time = "1460h" # 60 days
-}
-
 # ---------------------------------------------------------------------------
 # islandgetaway — gate preview deployments (*.pages.dev) behind Access
 # ---------------------------------------------------------------------------

--- a/tf/infra/singletons/cloudflare_access.tf
+++ b/tf/infra/singletons/cloudflare_access.tf
@@ -1,0 +1,38 @@
+# Cloudflare Zero Trust organisation — account-level singleton.
+# Must exist before any Access applications can be created.
+# The auth_domain becomes <team>.cloudflareaccess.com.
+resource "cloudflare_zero_trust_organization" "gpo" {
+  account_id                         = data.sops_file.secrets.data["cloudflare_account_id"]
+  name                               = "GPO"
+  auth_domain                        = "gpo"
+  is_ui_read_only                    = false
+  user_seat_expiration_inactive_time = "1460h" # 60 days
+}
+
+# ---------------------------------------------------------------------------
+# islandgetaway — gate preview deployments (*.pages.dev) behind Access
+# ---------------------------------------------------------------------------
+resource "cloudflare_zero_trust_access_application" "islandgetaway_previews" {
+  account_id       = data.sops_file.secrets.data["cloudflare_account_id"]
+  name             = "islandgetaway previews"
+  domain           = "*.islandgetaway-ca.pages.dev"
+  type             = "self_hosted"
+  session_duration = "24h"
+
+  # One-time PIN is enabled by default on all Cloudflare accounts; no IdP
+  # resource is needed.
+  allowed_idps              = []
+  auto_redirect_to_identity = false
+}
+
+resource "cloudflare_zero_trust_access_policy" "islandgetaway_previews_allow_gpo" {
+  account_id     = data.sops_file.secrets.data["cloudflare_account_id"]
+  application_id = cloudflare_zero_trust_access_application.islandgetaway_previews.id
+  name           = "Allow @gpo.ca"
+  precedence     = 1
+  decision       = "allow"
+
+  include {
+    email_domain = ["gpo.ca"]
+  }
+}


### PR DESCRIPTION
## Summary

- Enables preview deployments on the `islandgetaway` Pages project (`preview_deployment_setting = "none"` → `"all"`)
- Gates `*.islandgetaway-ca.pages.dev` behind Cloudflare Access (one-time PIN, `@gpo.ca` email domain)
- Production `islandgetaway.ca` is unaffected

## New resources (`cloudflare_access.tf`)

- `cloudflare_zero_trust_organization.gpo` — initialises Zero Trust at `gpo.cloudflareaccess.com`. If already created in the dashboard, import before applying: `tofu import cloudflare_zero_trust_organization.gpo <account_id>`
- `cloudflare_zero_trust_access_application.islandgetaway_previews` — protects `*.islandgetaway-ca.pages.dev`
- `cloudflare_zero_trust_access_policy.islandgetaway_previews_allow_gpo` — allows any `@gpo.ca` email via one-time PIN (no OAuth app required)

## Verification

Push any branch to `gpo/islandgetaway` and expect a Cloudflare bot PR comment with the preview URL within ~60s. Visiting that URL should redirect to the Access login page.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TsN1kXhNerB1xXDBG29YHB)_