### PR TITLE
Extend islandgetaway Access session duration to 1 week

### DIFF
--- a/tf/infra/singletons/cloudflare_access.tf
+++ b/tf/infra/singletons/cloudflare_access.tf
@@ -6,7 +6,7 @@ resource "cloudflare_zero_trust_access_application" "islandgetaway_previews" {
   name             = "islandgetaway previews"
   domain           = "*.islandgetaway-ca.pages.dev"
   type             = "self_hosted"
-  session_duration = "24h"
+  session_duration = "168h"
 
   # One-time PIN is enabled by default on all Cloudflare accounts; no IdP
   # resource is needed.


### PR DESCRIPTION
Changes `session_duration` from `"24h"` to `"168h"` on the `cloudflare_zero_trust_access_application.islandgetaway_previews` resource. Users who log in via OTP will stay authenticated for 7 days instead of 1.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TsN1kXhNerB1xXDBG29YHB)_