### PR TITLE
chore: update Superset to 6.1.0 (prod)

### DIFF
--- a/kubernetes/superset/prod/helmfile.yaml
+++ b/kubernetes/superset/prod/helmfile.yaml
@@ -7,6 +7,6 @@ releases:
 - name: superset
   namespace: superset
   chart: superset/superset
-  version: 0.15.0
+  version: 0.16.2
   values:
   - values.yaml

--- a/kubernetes/superset/prod/rendered/superset.yaml
+++ b/kubernetes/superset/prod/rendered/superset.yaml
@@ -236,7 +236,7 @@ metadata:
   namespace: superset
   labels:
     app: superset
-    chart: superset-0.15.0
+    chart: superset-0.16.2
     release: superset
     heritage: Helm
 spec:
@@ -258,7 +258,7 @@ metadata:
   namespace: superset
   labels:
     app: superset-worker
-    chart: superset-0.15.0
+    chart: superset-0.16.2
     release: superset
     heritage: Helm
 spec:
@@ -297,7 +297,7 @@ spec:
           name: wait-for-postgres-redis
       containers:
         - name: superset
-          image: northamerica-northeast2-docker.pkg.dev/gpo-eng-prod/gpo/apache-superset:v0.0.1
+          image: northamerica-northeast2-docker.pkg.dev/gpo-eng-prod/gpo/apache-superset:v0.0.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -338,7 +338,7 @@ metadata:
   namespace: superset
   labels:
     app: superset
-    chart: superset-0.15.0
+    chart: superset-0.16.2
     release: superset
     heritage: Helm
 spec:
@@ -379,7 +379,7 @@ spec:
           name: wait-for-postgres
       containers:
         - name: superset
-          image: northamerica-northeast2-docker.pkg.dev/gpo-eng-prod/gpo/apache-superset:v0.0.1
+          image: northamerica-northeast2-docker.pkg.dev/gpo-eng-prod/gpo/apache-superset:v0.0.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -576,7 +576,7 @@ metadata:
   namespace: superset
   labels:
     app: superset
-    chart: superset-0.15.0
+    chart: superset-0.16.2
     release: superset
     heritage: Helm
   annotations:
@@ -602,7 +602,7 @@ spec:
           name: wait-for-postgres
       containers:
         - name: superset-init-db
-          image: northamerica-northeast2-docker.pkg.dev/gpo-eng-prod/gpo/apache-superset:v0.0.1
+          image: northamerica-northeast2-docker.pkg.dev/gpo-eng-prod/gpo/apache-superset:v0.0.3
           envFrom:
             - secretRef:
                 name: superset-env

--- a/kubernetes/superset/prod/rendered/superset.yaml
+++ b/kubernetes/superset/prod/rendered/superset.yaml
@@ -11,6 +11,10 @@ metadata:
     helm.sh/chart: redis-17.9.4
     app.kubernetes.io/instance: superset
     app.kubernetes.io/managed-by: Helm
+spec:
+  template:
+    spec:
+      initContainers: []
 ---
 # Source: superset/charts/redis/templates/configmap.yaml
 apiVersion: v1
@@ -43,6 +47,10 @@ data:
     rename-command FLUSHDB ""
     rename-command FLUSHALL ""
     # End of replica configuration
+spec:
+  template:
+    spec:
+      initContainers: []
 ---
 # Source: superset/charts/redis/templates/health-configmap.yaml
 apiVersion: v1
@@ -150,6 +158,10 @@ data:
     "$script_dir/ping_liveness_local.sh" $1 || exit_status=$?
     "$script_dir/ping_liveness_master.sh" $1 || exit_status=$?
     exit $exit_status
+spec:
+  template:
+    spec:
+      initContainers: []
 ---
 # Source: superset/charts/redis/templates/scripts-configmap.yaml
 apiVersion: v1
@@ -178,6 +190,10 @@ data:
     ARGS+=("--include" "/opt/bitnami/redis/etc/redis.conf")
     ARGS+=("--include" "/opt/bitnami/redis/etc/master.conf")
     exec redis-server "${ARGS[@]}"
+spec:
+  template:
+    spec:
+      initContainers: []
 ---
 # Source: superset/charts/redis/templates/headless-svc.yaml
 apiVersion: v1
@@ -201,6 +217,9 @@ spec:
   selector:
     app.kubernetes.io/name: redis
     app.kubernetes.io/instance: superset
+  template:
+    spec:
+      initContainers: []
 ---
 # Source: superset/charts/redis/templates/master/service.yaml
 apiVersion: v1
@@ -227,6 +246,9 @@ spec:
     app.kubernetes.io/name: redis
     app.kubernetes.io/instance: superset
     app.kubernetes.io/component: master
+  template:
+    spec:
+      initContainers: []
 ---
 # Source: superset/templates/service.yaml
 apiVersion: v1
@@ -249,6 +271,9 @@ spec:
   selector:
     app: superset
     release: superset
+  template:
+    spec:
+      initContainers: []
 ---
 # Source: superset/templates/deployment-worker.yaml
 apiVersion: apps/v1
@@ -270,13 +295,13 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/superset_config.py: 7f9396795bb0a5a1b02cf8a9994fdfdd62b97e479a8f3c2bb04d1f7d638d65fa
+        checksum/superset_config.py: 9e67664480635c3f09ea2adbb061d10c143aff2dbe2a037fd036c2946ebaa390
         checksum/superset_bootstrap.sh: dc9a47141051ced34960c313860a55e03eb48c1fa36a0ed25c03ad60cd3b5c48
-        checksum/connections: c3d3ce69117f3ced7a541d038ebb96b49ca06c3234928cb895f0b3941e3c3c19
+        checksum/connections: 9d7f9aa15a1c2500ba4c5049cb934e8f5860d207d2dd5764b3282a326bc46067
         checksum/extraConfigs: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
         checksum/extraSecrets: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
         checksum/extraSecretEnv: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
-        checksum/configOverrides: 0613ddf2357c467fff163f9a6d8566106d8af79d622189c01d45bef2adb0eb79
+        checksum/configOverrides: 0e7800fd26efa8a8a5a7131ee24878ea1c816f833d221a02a70873e918973115
         checksum/configOverridesFiles: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
       labels:
         app: superset-worker
@@ -295,6 +320,9 @@ spec:
           image: apache/superset:dockerize
           imagePullPolicy: IfNotPresent
           name: wait-for-postgres-redis
+          resources:
+            limits:
+              memory: 256Mi
       containers:
         - name: superset
           image: northamerica-northeast2-docker.pkg.dev/gpo-eng-prod/gpo/apache-superset:v0.0.3
@@ -351,14 +379,14 @@ spec:
     metadata:
       annotations:
         # Force reload on config changes
-        checksum/superset_config.py: 7f9396795bb0a5a1b02cf8a9994fdfdd62b97e479a8f3c2bb04d1f7d638d65fa
+        checksum/superset_config.py: 9e67664480635c3f09ea2adbb061d10c143aff2dbe2a037fd036c2946ebaa390
         checksum/superset_init.sh: e6b1e8eac1f7a79a07a6c72a0e2ee6e09654eeb439c6bbe61bfd676917c41e02
         checksum/superset_bootstrap.sh: dc9a47141051ced34960c313860a55e03eb48c1fa36a0ed25c03ad60cd3b5c48
-        checksum/connections: c3d3ce69117f3ced7a541d038ebb96b49ca06c3234928cb895f0b3941e3c3c19
+        checksum/connections: 9d7f9aa15a1c2500ba4c5049cb934e8f5860d207d2dd5764b3282a326bc46067
         checksum/extraConfigs: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
         checksum/extraSecrets: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
         checksum/extraSecretEnv: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
-        checksum/configOverrides: 0613ddf2357c467fff163f9a6d8566106d8af79d622189c01d45bef2adb0eb79
+        checksum/configOverrides: 0e7800fd26efa8a8a5a7131ee24878ea1c816f833d221a02a70873e918973115
         checksum/configOverridesFiles: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
       labels:
         app: superset
@@ -377,6 +405,9 @@ spec:
           image: apache/superset:dockerize
           imagePullPolicy: IfNotPresent
           name: wait-for-postgres
+          resources:
+            limits:
+              memory: 256Mi
       containers:
         - name: superset
           image: northamerica-northeast2-docker.pkg.dev/gpo-eng-prod/gpo/apache-superset:v0.0.3
@@ -567,6 +598,7 @@ spec:
           emptyDir: {}
         - name: redis-data
           emptyDir: {}
+      initContainers: []
 ---
 # Source: superset/templates/init-job.yaml
 apiVersion: batch/v1
@@ -600,6 +632,9 @@ spec:
           image: apache/superset:dockerize
           imagePullPolicy: IfNotPresent
           name: wait-for-postgres
+          resources:
+            limits:
+              memory: 256Mi
       containers:
         - name: superset-init-db
           image: northamerica-northeast2-docker.pkg.dev/gpo-eng-prod/gpo/apache-superset:v0.0.3

--- a/kubernetes/superset/prod/values.yaml
+++ b/kubernetes/superset/prod/values.yaml
@@ -18,7 +18,7 @@ redis:
 # for MySQL and PostgreSQL drivers.
 image:
   repository: northamerica-northeast2-docker.pkg.dev/gpo-eng-prod/gpo/apache-superset
-  tag: v0.0.1
+  tag: v0.0.3
 # Enabling feature flags. Note this is Python code injected into config.py.
 # See https://github.com/apache/superset/blob/master/RESOURCES/FEATURE_FLAGS.md
 # and https://github.com/apache/superset/tree/master/helm/superset#values for
@@ -27,4 +27,6 @@ configOverrides:
   superset_config.py: |
     FEATURE_FLAGS = {
       'DASHBOARD_RBAC': True,
+      'DASHBOARD_VIRTUALIZATION_DEFER_DATA': True,
+      'MATRIXIFY': True,
     }


### PR DESCRIPTION
Upgrades Apache Superset to 6.1.0 on **prod**. Stage (#190) should be verified before merging this.

## Changes

- Upgrade Helm chart `superset/superset` from `0.15.0` → `0.16.2`
- Custom image tag `v0.0.3` (6.1.0 base + mysqlclient + psycopg2-binary)
- Strip init container cpu/memory requests via render filter, keep 256Mi memory limit
- Enable `DASHBOARD_VIRTUALIZATION_DEFER_DATA` and `MATRIXIFY` feature flags

Note: Dockerfile and `filter-helm-templates.sh` changes are already in main from the stage PR.

## Test plan

- [x] Stage verified post-deploy
- [x] Docker image `v0.0.3` pushed to `northamerica-northeast2-docker.pkg.dev/gpo-eng-prod/gpo/apache-superset`
- [x] Re-render manifests locally: delete `rendered/superset.yaml`, run `mise run superset:prod:render`, commit, push
- [ ] ArgoCD syncs prod successfully
- [ ] Superset UI loads and dashboards render correctly on prod

https://claude.ai/code/session_01R3G7PnRLXHyanWGGZetxwJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3G7PnRLXHyanWGGZetxwJ)_