### PR TITLE
fix: infinite argo sync due to empty initContainers blocks

### DIFF
--- a/kubernetes/superset/filter-helm-templates.sh
+++ b/kubernetes/superset/filter-helm-templates.sh
@@ -13,8 +13,8 @@ yq ea '
 ' - | \
 yq ea '(.spec.template.spec.initContainers[]?.resources) |= del(.requests)' - | \
 yq ea '
-  if .spec.template.spec.initContainers == [] then del(.spec.template.spec.initContainers) else . end |
-  if .spec.template.spec == {} then del(.spec.template.spec) else . end |
-  if .spec.template == {} then del(.spec.template) else . end |
-  if .spec == {} then del(.spec) else . end
+  del(.spec.template.spec.initContainers | select(. == [])) |
+  del(.spec.template.spec | select(. == {})) |
+  del(.spec.template | select(. == {})) |
+  del(.spec | select(. == {}))
 ' -

--- a/kubernetes/superset/filter-helm-templates.sh
+++ b/kubernetes/superset/filter-helm-templates.sh
@@ -12,15 +12,7 @@ yq ea '
   )
 ' - | \
 yq ea '(.spec.template.spec.initContainers[]?.resources) |= del(.requests)' - | \
-python3 -c '
-import sys, re
-content = sys.stdin.read()
-# Remove full spec.template.spec tree when initContainers: [] is its only child
-content = re.sub(r"spec:\n  template:\n    spec:\n      initContainers: \[\]\n", "", content)
-# Remove lone initContainers: [] (sibling of containers/volumes in a real pod spec)
-content = re.sub(r"      initContainers: \[\]\n", "", content)
-# Remove orphaned empty parent nodes left before a document separator
-content = re.sub(r"    spec:\n(?=---)", "", content)
-content = re.sub(r"  template:\n(?=---)", "", content)
-sys.stdout.write(content)
-'
+yq ea 'del(.spec.template.spec.initContainers | select(tag == "!!seq" and length == 0))' - | \
+yq ea 'del(.spec.template.spec | select(tag == "!!map" and length == 0))' - | \
+yq ea 'del(.spec.template | select(tag == "!!map" and length == 0))' - | \
+yq ea 'del(.spec | select(tag == "!!map" and length == 0))' -

--- a/kubernetes/superset/filter-helm-templates.sh
+++ b/kubernetes/superset/filter-helm-templates.sh
@@ -13,8 +13,8 @@ yq ea '
 ' - | \
 yq ea '(.spec.template.spec.initContainers[]?.resources) |= del(.requests)' - | \
 yq ea '
-  del(.spec.template.spec.initContainers | select(length == 0)) |
-  del(.spec.template.spec | select(length == 0)) |
-  del(.spec.template | select(length == 0)) |
-  del(.spec | select(length == 0))
+  if .spec.template.spec.initContainers == [] then del(.spec.template.spec.initContainers) else . end |
+  if .spec.template.spec == {} then del(.spec.template.spec) else . end |
+  if .spec.template == {} then del(.spec.template) else . end |
+  if .spec == {} then del(.spec) else . end
 ' -

--- a/kubernetes/superset/filter-helm-templates.sh
+++ b/kubernetes/superset/filter-helm-templates.sh
@@ -12,9 +12,15 @@ yq ea '
   )
 ' - | \
 yq ea '(.spec.template.spec.initContainers[]?.resources) |= del(.requests)' - | \
-yq ea '
-  (.spec.template.spec | select(.initContainers == [])) |= del(.initContainers) |
-  (.spec.template | select(.spec == {})) |= del(.spec) |
-  (.spec | select(.template == {})) |= del(.template) |
-  select(.spec == {}) |= del(.spec)
-' -
+python3 -c '
+import sys, re
+content = sys.stdin.read()
+# Remove full spec.template.spec tree when initContainers: [] is its only child
+content = re.sub(r"spec:\n  template:\n    spec:\n      initContainers: \[\]\n", "", content)
+# Remove lone initContainers: [] (sibling of containers/volumes in a real pod spec)
+content = re.sub(r"      initContainers: \[\]\n", "", content)
+# Remove orphaned empty parent nodes left before a document separator
+content = re.sub(r"    spec:\n(?=---)", "", content)
+content = re.sub(r"  template:\n(?=---)", "", content)
+sys.stdout.write(content)
+'

--- a/kubernetes/superset/filter-helm-templates.sh
+++ b/kubernetes/superset/filter-helm-templates.sh
@@ -13,8 +13,8 @@ yq ea '
 ' - | \
 yq ea '(.spec.template.spec.initContainers[]?.resources) |= del(.requests)' - | \
 yq ea '
-  del(.spec.template.spec.initContainers | select(. == [])) |
-  del(.spec.template.spec | select(. == {})) |
-  del(.spec.template | select(. == {})) |
-  del(.spec | select(. == {}))
+  (.spec.template.spec | select(.initContainers == [])) |= del(.initContainers) |
+  (.spec.template | select(.spec == {})) |= del(.spec) |
+  (.spec | select(.template == {})) |= del(.template) |
+  select(.spec == {}) |= del(.spec)
 ' -

--- a/kubernetes/superset/filter-helm-templates.sh
+++ b/kubernetes/superset/filter-helm-templates.sh
@@ -11,4 +11,10 @@ yq ea '
     )
   )
 ' - | \
-yq ea '(.spec.template.spec.initContainers[]?.resources) |= del(.requests)' -
+yq ea '(.spec.template.spec.initContainers[]?.resources) |= del(.requests)' - | \
+yq ea '
+  del(.spec.template.spec.initContainers | select(length == 0)) |
+  del(.spec.template.spec | select(length == 0)) |
+  del(.spec.template | select(length == 0)) |
+  del(.spec | select(length == 0))
+' -

--- a/kubernetes/superset/prod/rendered/superset.yaml
+++ b/kubernetes/superset/prod/rendered/superset.yaml
@@ -11,10 +11,6 @@ metadata:
     helm.sh/chart: redis-17.9.4
     app.kubernetes.io/instance: superset
     app.kubernetes.io/managed-by: Helm
-spec:
-  template:
-    spec:
-      initContainers: []
 ---
 # Source: superset/charts/redis/templates/configmap.yaml
 apiVersion: v1
@@ -47,10 +43,6 @@ data:
     rename-command FLUSHDB ""
     rename-command FLUSHALL ""
     # End of replica configuration
-spec:
-  template:
-    spec:
-      initContainers: []
 ---
 # Source: superset/charts/redis/templates/health-configmap.yaml
 apiVersion: v1
@@ -158,10 +150,6 @@ data:
     "$script_dir/ping_liveness_local.sh" $1 || exit_status=$?
     "$script_dir/ping_liveness_master.sh" $1 || exit_status=$?
     exit $exit_status
-spec:
-  template:
-    spec:
-      initContainers: []
 ---
 # Source: superset/charts/redis/templates/scripts-configmap.yaml
 apiVersion: v1
@@ -190,10 +178,6 @@ data:
     ARGS+=("--include" "/opt/bitnami/redis/etc/redis.conf")
     ARGS+=("--include" "/opt/bitnami/redis/etc/master.conf")
     exec redis-server "${ARGS[@]}"
-spec:
-  template:
-    spec:
-      initContainers: []
 ---
 # Source: superset/charts/redis/templates/headless-svc.yaml
 apiVersion: v1
@@ -217,9 +201,6 @@ spec:
   selector:
     app.kubernetes.io/name: redis
     app.kubernetes.io/instance: superset
-  template:
-    spec:
-      initContainers: []
 ---
 # Source: superset/charts/redis/templates/master/service.yaml
 apiVersion: v1
@@ -246,9 +227,6 @@ spec:
     app.kubernetes.io/name: redis
     app.kubernetes.io/instance: superset
     app.kubernetes.io/component: master
-  template:
-    spec:
-      initContainers: []
 ---
 # Source: superset/templates/service.yaml
 apiVersion: v1
@@ -271,9 +249,6 @@ spec:
   selector:
     app: superset
     release: superset
-  template:
-    spec:
-      initContainers: []
 ---
 # Source: superset/templates/deployment-worker.yaml
 apiVersion: apps/v1
@@ -598,7 +573,6 @@ spec:
           emptyDir: {}
         - name: redis-data
           emptyDir: {}
-      initContainers: []
 ---
 # Source: superset/templates/init-job.yaml
 apiVersion: batch/v1

--- a/kubernetes/superset/prod/rendered/superset.yaml
+++ b/kubernetes/superset/prod/rendered/superset.yaml
@@ -11,6 +11,10 @@ metadata:
     helm.sh/chart: redis-17.9.4
     app.kubernetes.io/instance: superset
     app.kubernetes.io/managed-by: Helm
+spec:
+  template:
+    spec:
+      initContainers: []
 ---
 # Source: superset/charts/redis/templates/configmap.yaml
 apiVersion: v1
@@ -43,6 +47,10 @@ data:
     rename-command FLUSHDB ""
     rename-command FLUSHALL ""
     # End of replica configuration
+spec:
+  template:
+    spec:
+      initContainers: []
 ---
 # Source: superset/charts/redis/templates/health-configmap.yaml
 apiVersion: v1
@@ -150,6 +158,10 @@ data:
     "$script_dir/ping_liveness_local.sh" $1 || exit_status=$?
     "$script_dir/ping_liveness_master.sh" $1 || exit_status=$?
     exit $exit_status
+spec:
+  template:
+    spec:
+      initContainers: []
 ---
 # Source: superset/charts/redis/templates/scripts-configmap.yaml
 apiVersion: v1
@@ -178,6 +190,10 @@ data:
     ARGS+=("--include" "/opt/bitnami/redis/etc/redis.conf")
     ARGS+=("--include" "/opt/bitnami/redis/etc/master.conf")
     exec redis-server "${ARGS[@]}"
+spec:
+  template:
+    spec:
+      initContainers: []
 ---
 # Source: superset/charts/redis/templates/headless-svc.yaml
 apiVersion: v1
@@ -201,6 +217,9 @@ spec:
   selector:
     app.kubernetes.io/name: redis
     app.kubernetes.io/instance: superset
+  template:
+    spec:
+      initContainers: []
 ---
 # Source: superset/charts/redis/templates/master/service.yaml
 apiVersion: v1
@@ -227,6 +246,9 @@ spec:
     app.kubernetes.io/name: redis
     app.kubernetes.io/instance: superset
     app.kubernetes.io/component: master
+  template:
+    spec:
+      initContainers: []
 ---
 # Source: superset/templates/service.yaml
 apiVersion: v1
@@ -249,6 +271,9 @@ spec:
   selector:
     app: superset
     release: superset
+  template:
+    spec:
+      initContainers: []
 ---
 # Source: superset/templates/deployment-worker.yaml
 apiVersion: apps/v1
@@ -573,6 +598,7 @@ spec:
           emptyDir: {}
         - name: redis-data
           emptyDir: {}
+      initContainers: []
 ---
 # Source: superset/templates/init-job.yaml
 apiVersion: batch/v1

--- a/kubernetes/superset/prod/rendered/superset.yaml
+++ b/kubernetes/superset/prod/rendered/superset.yaml
@@ -201,8 +201,6 @@ spec:
   selector:
     app.kubernetes.io/name: redis
     app.kubernetes.io/instance: superset
-  template:
-    spec:
 ---
 # Source: superset/charts/redis/templates/master/service.yaml
 apiVersion: v1
@@ -229,8 +227,6 @@ spec:
     app.kubernetes.io/name: redis
     app.kubernetes.io/instance: superset
     app.kubernetes.io/component: master
-  template:
-    spec:
 ---
 # Source: superset/templates/service.yaml
 apiVersion: v1
@@ -253,8 +249,6 @@ spec:
   selector:
     app: superset
     release: superset
-  template:
-    spec:
 ---
 # Source: superset/templates/deployment-worker.yaml
 apiVersion: apps/v1

--- a/kubernetes/superset/prod/rendered/superset.yaml
+++ b/kubernetes/superset/prod/rendered/superset.yaml
@@ -11,10 +11,6 @@ metadata:
     helm.sh/chart: redis-17.9.4
     app.kubernetes.io/instance: superset
     app.kubernetes.io/managed-by: Helm
-spec:
-  template:
-    spec:
-      initContainers: []
 ---
 # Source: superset/charts/redis/templates/configmap.yaml
 apiVersion: v1
@@ -47,10 +43,6 @@ data:
     rename-command FLUSHDB ""
     rename-command FLUSHALL ""
     # End of replica configuration
-spec:
-  template:
-    spec:
-      initContainers: []
 ---
 # Source: superset/charts/redis/templates/health-configmap.yaml
 apiVersion: v1
@@ -158,10 +150,6 @@ data:
     "$script_dir/ping_liveness_local.sh" $1 || exit_status=$?
     "$script_dir/ping_liveness_master.sh" $1 || exit_status=$?
     exit $exit_status
-spec:
-  template:
-    spec:
-      initContainers: []
 ---
 # Source: superset/charts/redis/templates/scripts-configmap.yaml
 apiVersion: v1
@@ -190,10 +178,6 @@ data:
     ARGS+=("--include" "/opt/bitnami/redis/etc/redis.conf")
     ARGS+=("--include" "/opt/bitnami/redis/etc/master.conf")
     exec redis-server "${ARGS[@]}"
-spec:
-  template:
-    spec:
-      initContainers: []
 ---
 # Source: superset/charts/redis/templates/headless-svc.yaml
 apiVersion: v1
@@ -219,7 +203,6 @@ spec:
     app.kubernetes.io/instance: superset
   template:
     spec:
-      initContainers: []
 ---
 # Source: superset/charts/redis/templates/master/service.yaml
 apiVersion: v1
@@ -248,7 +231,6 @@ spec:
     app.kubernetes.io/component: master
   template:
     spec:
-      initContainers: []
 ---
 # Source: superset/templates/service.yaml
 apiVersion: v1
@@ -273,7 +255,6 @@ spec:
     release: superset
   template:
     spec:
-      initContainers: []
 ---
 # Source: superset/templates/deployment-worker.yaml
 apiVersion: apps/v1
@@ -598,7 +579,6 @@ spec:
           emptyDir: {}
         - name: redis-data
           emptyDir: {}
-      initContainers: []
 ---
 # Source: superset/templates/init-job.yaml
 apiVersion: batch/v1

--- a/kubernetes/superset/stage/rendered/superset.yaml
+++ b/kubernetes/superset/stage/rendered/superset.yaml
@@ -11,10 +11,6 @@ metadata:
     helm.sh/chart: redis-17.9.4
     app.kubernetes.io/instance: superset
     app.kubernetes.io/managed-by: Helm
-spec:
-  template:
-    spec:
-      initContainers: []
 ---
 # Source: superset/charts/redis/templates/configmap.yaml
 apiVersion: v1
@@ -47,10 +43,6 @@ data:
     rename-command FLUSHDB ""
     rename-command FLUSHALL ""
     # End of replica configuration
-spec:
-  template:
-    spec:
-      initContainers: []
 ---
 # Source: superset/charts/redis/templates/health-configmap.yaml
 apiVersion: v1
@@ -158,10 +150,6 @@ data:
     "$script_dir/ping_liveness_local.sh" $1 || exit_status=$?
     "$script_dir/ping_liveness_master.sh" $1 || exit_status=$?
     exit $exit_status
-spec:
-  template:
-    spec:
-      initContainers: []
 ---
 # Source: superset/charts/redis/templates/scripts-configmap.yaml
 apiVersion: v1
@@ -190,10 +178,6 @@ data:
     ARGS+=("--include" "/opt/bitnami/redis/etc/redis.conf")
     ARGS+=("--include" "/opt/bitnami/redis/etc/master.conf")
     exec redis-server "${ARGS[@]}"
-spec:
-  template:
-    spec:
-      initContainers: []
 ---
 # Source: superset/charts/redis/templates/headless-svc.yaml
 apiVersion: v1
@@ -217,9 +201,6 @@ spec:
   selector:
     app.kubernetes.io/name: redis
     app.kubernetes.io/instance: superset
-  template:
-    spec:
-      initContainers: []
 ---
 # Source: superset/charts/redis/templates/master/service.yaml
 apiVersion: v1
@@ -246,9 +227,6 @@ spec:
     app.kubernetes.io/name: redis
     app.kubernetes.io/instance: superset
     app.kubernetes.io/component: master
-  template:
-    spec:
-      initContainers: []
 ---
 # Source: superset/templates/service.yaml
 apiVersion: v1
@@ -271,9 +249,6 @@ spec:
   selector:
     app: superset
     release: superset
-  template:
-    spec:
-      initContainers: []
 ---
 # Source: superset/templates/deployment-worker.yaml
 apiVersion: apps/v1
@@ -598,7 +573,6 @@ spec:
           emptyDir: {}
         - name: redis-data
           emptyDir: {}
-      initContainers: []
 ---
 # Source: superset/templates/init-job.yaml
 apiVersion: batch/v1

--- a/kubernetes/superset/stage/rendered/superset.yaml
+++ b/kubernetes/superset/stage/rendered/superset.yaml
@@ -11,6 +11,10 @@ metadata:
     helm.sh/chart: redis-17.9.4
     app.kubernetes.io/instance: superset
     app.kubernetes.io/managed-by: Helm
+spec:
+  template:
+    spec:
+      initContainers: []
 ---
 # Source: superset/charts/redis/templates/configmap.yaml
 apiVersion: v1
@@ -43,6 +47,10 @@ data:
     rename-command FLUSHDB ""
     rename-command FLUSHALL ""
     # End of replica configuration
+spec:
+  template:
+    spec:
+      initContainers: []
 ---
 # Source: superset/charts/redis/templates/health-configmap.yaml
 apiVersion: v1
@@ -150,6 +158,10 @@ data:
     "$script_dir/ping_liveness_local.sh" $1 || exit_status=$?
     "$script_dir/ping_liveness_master.sh" $1 || exit_status=$?
     exit $exit_status
+spec:
+  template:
+    spec:
+      initContainers: []
 ---
 # Source: superset/charts/redis/templates/scripts-configmap.yaml
 apiVersion: v1
@@ -178,6 +190,10 @@ data:
     ARGS+=("--include" "/opt/bitnami/redis/etc/redis.conf")
     ARGS+=("--include" "/opt/bitnami/redis/etc/master.conf")
     exec redis-server "${ARGS[@]}"
+spec:
+  template:
+    spec:
+      initContainers: []
 ---
 # Source: superset/charts/redis/templates/headless-svc.yaml
 apiVersion: v1
@@ -201,6 +217,9 @@ spec:
   selector:
     app.kubernetes.io/name: redis
     app.kubernetes.io/instance: superset
+  template:
+    spec:
+      initContainers: []
 ---
 # Source: superset/charts/redis/templates/master/service.yaml
 apiVersion: v1
@@ -227,6 +246,9 @@ spec:
     app.kubernetes.io/name: redis
     app.kubernetes.io/instance: superset
     app.kubernetes.io/component: master
+  template:
+    spec:
+      initContainers: []
 ---
 # Source: superset/templates/service.yaml
 apiVersion: v1
@@ -249,6 +271,9 @@ spec:
   selector:
     app: superset
     release: superset
+  template:
+    spec:
+      initContainers: []
 ---
 # Source: superset/templates/deployment-worker.yaml
 apiVersion: apps/v1
@@ -573,6 +598,7 @@ spec:
           emptyDir: {}
         - name: redis-data
           emptyDir: {}
+      initContainers: []
 ---
 # Source: superset/templates/init-job.yaml
 apiVersion: batch/v1

--- a/kubernetes/superset/stage/rendered/superset.yaml
+++ b/kubernetes/superset/stage/rendered/superset.yaml
@@ -201,8 +201,6 @@ spec:
   selector:
     app.kubernetes.io/name: redis
     app.kubernetes.io/instance: superset
-  template:
-    spec:
 ---
 # Source: superset/charts/redis/templates/master/service.yaml
 apiVersion: v1
@@ -229,8 +227,6 @@ spec:
     app.kubernetes.io/name: redis
     app.kubernetes.io/instance: superset
     app.kubernetes.io/component: master
-  template:
-    spec:
 ---
 # Source: superset/templates/service.yaml
 apiVersion: v1
@@ -253,8 +249,6 @@ spec:
   selector:
     app: superset
     release: superset
-  template:
-    spec:
 ---
 # Source: superset/templates/deployment-worker.yaml
 apiVersion: apps/v1

--- a/kubernetes/superset/stage/rendered/superset.yaml
+++ b/kubernetes/superset/stage/rendered/superset.yaml
@@ -11,10 +11,6 @@ metadata:
     helm.sh/chart: redis-17.9.4
     app.kubernetes.io/instance: superset
     app.kubernetes.io/managed-by: Helm
-spec:
-  template:
-    spec:
-      initContainers: []
 ---
 # Source: superset/charts/redis/templates/configmap.yaml
 apiVersion: v1
@@ -47,10 +43,6 @@ data:
     rename-command FLUSHDB ""
     rename-command FLUSHALL ""
     # End of replica configuration
-spec:
-  template:
-    spec:
-      initContainers: []
 ---
 # Source: superset/charts/redis/templates/health-configmap.yaml
 apiVersion: v1
@@ -158,10 +150,6 @@ data:
     "$script_dir/ping_liveness_local.sh" $1 || exit_status=$?
     "$script_dir/ping_liveness_master.sh" $1 || exit_status=$?
     exit $exit_status
-spec:
-  template:
-    spec:
-      initContainers: []
 ---
 # Source: superset/charts/redis/templates/scripts-configmap.yaml
 apiVersion: v1
@@ -190,10 +178,6 @@ data:
     ARGS+=("--include" "/opt/bitnami/redis/etc/redis.conf")
     ARGS+=("--include" "/opt/bitnami/redis/etc/master.conf")
     exec redis-server "${ARGS[@]}"
-spec:
-  template:
-    spec:
-      initContainers: []
 ---
 # Source: superset/charts/redis/templates/headless-svc.yaml
 apiVersion: v1
@@ -219,7 +203,6 @@ spec:
     app.kubernetes.io/instance: superset
   template:
     spec:
-      initContainers: []
 ---
 # Source: superset/charts/redis/templates/master/service.yaml
 apiVersion: v1
@@ -248,7 +231,6 @@ spec:
     app.kubernetes.io/component: master
   template:
     spec:
-      initContainers: []
 ---
 # Source: superset/templates/service.yaml
 apiVersion: v1
@@ -273,7 +255,6 @@ spec:
     release: superset
   template:
     spec:
-      initContainers: []
 ---
 # Source: superset/templates/deployment-worker.yaml
 apiVersion: apps/v1
@@ -598,7 +579,6 @@ spec:
           emptyDir: {}
         - name: redis-data
           emptyDir: {}
-      initContainers: []
 ---
 # Source: superset/templates/init-job.yaml
 apiVersion: batch/v1


### PR DESCRIPTION
## Summary

- Helm emits `spec.template.spec.initContainers: []` on resources that have no init containers (ServiceAccount, ConfigMap, etc.), causing Argo CD to report superset as out of sync
- Added a `yq` cascade to `filter-helm-templates.sh` that deletes the empty `initContainers` key and walks up the tree removing now-empty parents (`spec.template.spec`, `spec.template`, `spec`)
- Applied the same fix directly to the existing prod and stage rendered YAML files (removes 20 lines each)

## Test plan

- [ ] Confirm Argo CD reports superset as synced after this merges
- [ ] Re-render superset helm templates and verify `initContainers: []` no longer appears in the output

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMcatJsnXesSGRxfAvgTcd)_