### PR TITLE
Add Superset MCP server (stage) as a web-pod sidecar

### DIFF
--- a/kubernetes/superset/README.md
+++ b/kubernetes/superset/README.md
@@ -60,3 +60,71 @@ To undeploy Superset, run:
 helm uninstall -n superset superset
 kubectl delete -f kubernetes/superset/<stage|prod>/ -f kubernetes/superset/resources/
 ```
+
+# MCP server
+
+Superset ships a built-in [MCP server](https://superset.apache.org/admin-docs/configuration/mcp-server)
+(`superset mcp run`) that lets MCP clients (Claude, Cursor, etc.) drive Superset
+through its existing RBAC. We run it **stage only** for now as a sidecar in the
+Superset web pod (`supersetNode.extraContainers` in `stage/values.yaml`),
+listening on port `5008`. The `superset-mcp` Service exposes it in-cluster and
+the `HTTPRoute` routes `https://superset.gpotoolsstage.ca/mcp` to it.
+
+Auth is HS256 JWT (`MCP_AUTH_ENABLED = True`): clients send a bearer token signed
+with the shared secret `MCP_JWT_SECRET`. RBAC is enforced on every tool call.
+
+## What lives where
+
+- **Image** — `fastmcp` is added in `docker/Dockerfile` (not reliably bundled in
+  the 6.1.0 base), so the image must be rebuilt and the tag bumped to `v0.0.4`.
+- **Sidecar + intent config** — `stage/values.yaml` (`extraContainers` and the
+  `MCP_*` block in `configOverrides`).
+- **Service** — `stage/mcp-service.yaml` (the chart only makes the web Service).
+- **Route** — the `/mcp` rule in `stage/httproute.yaml`.
+
+> Note: these edits are made directly in the `stage/` files (as the brand-theme
+> change was), **not** in `templates/`. The values template is already stale
+> (it predates the theme), so running `mise superset:genk8s` would regress both
+> the theme and this change — avoid it for superset until the template is
+> reconciled.
+
+## Required out-of-band steps
+
+The deployed config and env do **not** come from this repo's `configOverrides`:
+`filter-helm-templates.sh` strips the helm-generated `superset-config` and
+`superset-env` Secrets, and External Secrets replaces them from GCP Secret
+Manager. So before this works at runtime:
+
+1. **Build and push the image with `fastmcp`, tagged `v0.0.4`:**
+
+   ```sh
+   mise superset:build
+   # tag + push the result to the stage Artifact Registry as
+   # .../apache-superset:v0.0.4
+   ```
+
+2. **Sync `superset_config.py` to the GCP SM `superset-config` secret** — the
+   value that's actually mounted. It must include the `MCP_*` block from
+   `stage/values.yaml` (alongside the existing theme/feature flags).
+
+3. **Add `MCP_JWT_SECRET` to the GCP SM `superset-env` secret** — a strong random
+   value used to sign and verify the JWTs.
+
+ArgoCD then syncs `stage/rendered` + `stage/`.
+
+## Connecting a client
+
+Mint an HS256 JWT signed with `MCP_JWT_SECRET`, with `iss = gpo-superset-mcp`
+and `aud = superset-mcp-stage`, then point your client at the endpoint:
+
+```json
+{
+  "mcpServers": {
+    "superset": {
+      "type": "url",
+      "url": "https://superset.gpotoolsstage.ca/mcp",
+      "headers": { "Authorization": "Bearer <token>" }
+    }
+  }
+}
+```

--- a/kubernetes/superset/docker/Dockerfile
+++ b/kubernetes/superset/docker/Dockerfile
@@ -10,10 +10,14 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     pkg-config
 
+# fastmcp powers the built-in MCP server (`superset mcp run`). It is not
+# reliably bundled in the base image, so we install it explicitly to guarantee
+# the MCP sidecar can start.
 RUN . /app/.venv/bin/activate && \
     uv pip install \
     mysqlclient \
-    psycopg2-binary
+    psycopg2-binary \
+    fastmcp
 
 USER superset
 

--- a/kubernetes/superset/stage/httproute.yaml
+++ b/kubernetes/superset/stage/httproute.yaml
@@ -16,6 +16,15 @@ spec:
   hostnames:
   - "superset.gpotoolsstage.ca"
   rules:
+  # Route the MCP endpoint to the sidecar (port 5008). A longer path prefix
+  # takes precedence over the catch-all rule below, so /mcp* lands here.
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /mcp
+    backendRefs:
+    - name: superset-mcp
+      port: 5008
   - backendRefs:
     - name: superset
       port: 8088

--- a/kubernetes/superset/stage/mcp-service.yaml
+++ b/kubernetes/superset/stage/mcp-service.yaml
@@ -1,0 +1,22 @@
+# Service for the MCP sidecar (superset mcp run, port 5008). The chart only
+# creates a Service for the web process (port 8088), so this is a plain
+# manifest. It selects the same supersetNode pods, where the `mcp` sidecar
+# listens on 5008. The HTTPRoute sends /mcp here.
+apiVersion: v1
+kind: Service
+metadata:
+  name: superset-mcp
+  namespace: superset
+  labels:
+    app: superset
+    release: superset
+spec:
+  type: ClusterIP
+  ports:
+  - port: 5008
+    targetPort: mcp
+    protocol: TCP
+    name: mcp
+  selector:
+    app: superset
+    release: superset

--- a/kubernetes/superset/stage/rendered/superset.yaml
+++ b/kubernetes/superset/stage/rendered/superset.yaml
@@ -325,7 +325,7 @@ spec:
               memory: 256Mi
       containers:
         - name: superset
-          image: northamerica-northeast2-docker.pkg.dev/gpo-eng-stage/gpo/apache-superset:v0.0.3
+          image: northamerica-northeast2-docker.pkg.dev/gpo-eng-stage/gpo/apache-superset:v0.0.4
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -410,7 +410,7 @@ spec:
               memory: 256Mi
       containers:
         - name: superset
-          image: northamerica-northeast2-docker.pkg.dev/gpo-eng-stage/gpo/apache-superset:v0.0.3
+          image: northamerica-northeast2-docker.pkg.dev/gpo-eng-stage/gpo/apache-superset:v0.0.4
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -458,6 +458,27 @@ spec:
             successThreshold: 1
             timeoutSeconds: 1
           resources: {}
+        # MCP server sidecar (supersetNode.extraContainers in values.yaml).
+        # Shares the superset-config and superset-env secrets with the web
+        # container. Exposed in-cluster by the superset-mcp Service on 5008.
+        - name: mcp
+          image: northamerica-northeast2-docker.pkg.dev/gpo-eng-stage/gpo/apache-superset:v0.0.4
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - . /app/pythonpath/superset_bootstrap.sh; superset mcp run --host 0.0.0.0 --port 5008
+          envFrom:
+            - secretRef:
+                name: superset-env
+          volumeMounts:
+            - name: superset-config
+              mountPath: /app/pythonpath
+              readOnly: true
+          ports:
+            - name: mcp
+              containerPort: 5008
+              protocol: TCP
       volumes:
         - name: superset-config
           secret:
@@ -637,7 +658,7 @@ spec:
               memory: 256Mi
       containers:
         - name: superset-init-db
-          image: northamerica-northeast2-docker.pkg.dev/gpo-eng-stage/gpo/apache-superset:v0.0.3
+          image: northamerica-northeast2-docker.pkg.dev/gpo-eng-stage/gpo/apache-superset:v0.0.4
           envFrom:
             - secretRef:
                 name: superset-env

--- a/kubernetes/superset/stage/values.yaml
+++ b/kubernetes/superset/stage/values.yaml
@@ -7,6 +7,30 @@ supersetNode:
   connections:
     # default hostname provided by cnpg
     db_host: superset-rw
+  # MCP server sidecar. Runs `superset mcp run` in the same pod as the web
+  # process so it shares the superset-config (superset_config.py) and
+  # superset-env secrets. Exposed in-cluster on 5008 by the superset-mcp
+  # Service and routed publicly at /mcp by the HTTPRoute. Keep this image in
+  # sync with `image.tag` below.
+  extraContainers:
+  - name: mcp
+    image: northamerica-northeast2-docker.pkg.dev/gpo-eng-stage/gpo/apache-superset:v0.0.4
+    imagePullPolicy: IfNotPresent
+    command:
+    - /bin/sh
+    - -c
+    - . /app/pythonpath/superset_bootstrap.sh; superset mcp run --host 0.0.0.0 --port 5008
+    envFrom:
+    - secretRef:
+        name: superset-env
+    volumeMounts:
+    - name: superset-config
+      mountPath: /app/pythonpath
+      readOnly: true
+    ports:
+    - name: mcp
+      containerPort: 5008
+      protocol: TCP
 
 redis:
   image:
@@ -18,13 +42,21 @@ redis:
 # for MySQL and PostgreSQL drivers.
 image:
   repository: northamerica-northeast2-docker.pkg.dev/gpo-eng-stage/gpo/apache-superset
-  tag: v0.0.3
+  tag: v0.0.4
 # Enabling feature flags. Note this is Python code injected into config.py.
 # See https://github.com/apache/superset/blob/master/RESOURCES/FEATURE_FLAGS.md
 # and https://github.com/apache/superset/tree/master/helm/superset#values for
 # details.
+#
+# NOTE: the helm-generated `superset-config` Secret is stripped by
+# filter-helm-templates.sh and replaced by an External Secret sourced from the
+# GCP Secret Manager secret `superset-config`. So this block is the intended
+# superset_config.py, but it only takes effect once its contents are pushed to
+# the GCP SM `superset-config` value. See README.md ("MCP server").
 configOverrides:
   superset_config.py: |
+    import os
+
     FEATURE_FLAGS = {
       'DASHBOARD_RBAC': True,
       'DASHBOARD_VIRTUALIZATION_DEFER_DATA': True,
@@ -51,3 +83,16 @@ configOverrides:
       'algorithm': 'dark',
       'token': _GPO_THEME_TOKENS,
     }
+
+    # --- MCP server (`superset mcp run` sidecar) ---
+    MCP_SERVICE_HOST = "0.0.0.0"
+    MCP_SERVICE_PORT = 5008
+    MCP_SERVICE_URL = "https://superset.gpotoolsstage.ca/mcp"
+    # Enforce Superset RBAC on every MCP tool call.
+    MCP_RBAC_ENABLED = True
+    # Require a signed bearer token (HS256, shared secret from superset-env).
+    MCP_AUTH_ENABLED = True
+    MCP_JWT_ALGORITHM = "HS256"
+    MCP_JWT_SECRET = os.environ.get("MCP_JWT_SECRET")
+    MCP_JWT_ISSUER = "gpo-superset-mcp"
+    MCP_JWT_AUDIENCE = "superset-mcp-stage"

--- a/kubernetes/superset/templates/httproute.yaml.tmpl
+++ b/kubernetes/superset/templates/httproute.yaml.tmpl
@@ -15,6 +15,15 @@ spec:
   hostnames:
   - "${hostname}"
   rules:
+  # Route the MCP endpoint to the sidecar (port 5008). A longer path prefix
+  # takes precedence over the catch-all rule below, so /mcp* lands here.
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /mcp
+    backendRefs:
+    - name: superset-mcp
+      port: 5008
   - backendRefs:
     - name: superset
       port: 8088


### PR DESCRIPTION
Sets up the built-in Apache Superset [MCP server](https://superset.apache.org/admin-docs/configuration/mcp-server) in **stage only**, run as a sidecar in the Superset web pod. On current `main` (Superset **6.1.0**, chart `superset-0.16.2`, GPO brand theme) — the brand theme is preserved.

Supersedes #186 (closed, then the branch was force-pushed/redone for 6.1, which is why that one can't be reopened).

## Approach
- **Run mode:** `supersetNode.extraContainers` sidecar running `superset mcp run --host 0.0.0.0 --port 5008` in the web pod, sharing the `superset-config` (`superset_config.py`) and `superset-env` secrets with the web container.
- **Exposure:** new `superset-mcp` ClusterIP Service on 5008 + a `/mcp` `PathPrefix` rule on the existing `HTTPRoute` → `https://superset.gpotoolsstage.ca/mcp`.
- **Auth:** HS256 JWT (`MCP_AUTH_ENABLED = True`) with shared secret `MCP_JWT_SECRET`; Superset RBAC enforced on every tool call.

## Changes
| File | Change |
|---|---|
| `docker/Dockerfile` | add `fastmcp` (not reliably bundled in the 6.1.0 base) |
| `stage/values.yaml` | sidecar, `MCP_*` config (theme preserved), image bump `v0.0.3` → `v0.0.4` |
| `stage/mcp-service.yaml` | new ClusterIP Service on 5008 (chart only makes the web Service) |
| `stage/httproute.yaml` + `templates/httproute.yaml.tmpl` | `/mcp` rule → `superset-mcp:5008` |
| `stage/rendered/superset.yaml` | image bump + hand-added sidecar |
| `README.md` | MCP section + required out-of-band steps |

## ⚠️ Required out-of-band steps (this PR alone is not runtime-complete)
`filter-helm-templates.sh` strips the `superset-config`/`superset-env` Secrets — the real config & env come from **External Secrets / GCP Secret Manager**, not this repo's `configOverrides` (same reason the brand theme had to be synced there). So before it works:

1. **Build + push the image with `fastmcp`** tagged `…/apache-superset:v0.0.4` (`mise superset:build`).
2. **Sync `superset_config.py` to the GCP SM `superset-config` secret**, including the `MCP_*` block from `stage/values.yaml` (alongside the existing theme/flags).
3. **Add `MCP_JWT_SECRET`** (strong random) to the GCP SM `superset-env` secret.

## Notes
- Edits are made in the `stage/` files directly, matching how the brand-theme change (#193) was done. The `templates/values.yaml.tmpl` is **stale** (predates the theme), so `mise superset:genk8s` would regress both the theme and this change — superset is intentionally kept out of that flow until the template is reconciled. (`templates/httproute.yaml.tmpl` *is* in sync and was updated.)
- `helm`/the chart repo/TF-state/KMS are outside this sandbox's egress, so `mise superset:render` can't run here — the rendered manifest was edited by hand and validated with `yq` (parses clean; web pod = `[superset, mcp]`, worker untouched, embedded `superset_config.py` compiles). Worth a `mise superset:render` diff + a smoke test on stage after deploy (there were some `superset mcp run` app-context issues reported around 6.1.0rc1).
- prod intentionally untouched; replicate once stage is validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WX5z8ZbM84bjWostBxJ5JZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WX5z8ZbM84bjWostBxJ5JZ)_