### PR TITLE
Enforce repo safety rules with hooks; fix ignored settings key

### DIFF
--- a/.claude/hooks/guard-singletons-apply.sh
+++ b/.claude/hooks/guard-singletons-apply.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# PreToolUse guard for Bash calls: tf/infra/singletons is global production
+# with no staging equivalent, so any tofu/terraform apply touching it must be
+# explicitly confirmed by the user, even in auto-accept sessions.
+
+input=$(cat)
+command=$(echo "$input" | jq -r '.tool_input.command // empty')
+
+if echo "$command" | grep -qE '\b(tofu|terraform)\b.*\bapply\b' \
+  && echo "$command" | grep -q 'singletons'; then
+  cat <<'EOF'
+{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "ask", "permissionDecisionReason": "tf/infra/singletons is live production with no staging tier. Confirm this apply with the user before running it."}}
+EOF
+fi
+exit 0

--- a/.claude/hooks/protect-files.py
+++ b/.claude/hooks/protect-files.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""PreToolUse guard for Write/Edit calls.
+
+Enforces two repo rules mechanically (CLAUDE.md states them, this blocks them):
+1. secrets*.env files may only contain SOPS-encrypted values (ENC[...]) and
+   sops metadata — never plaintext secrets.
+2. Terraform stays in tf/, Kubernetes manifests stay in kubernetes/.
+
+Exit 0 allows the call; exit 2 blocks it and feeds stderr back to the model.
+"""
+
+import json
+import re
+import sys
+from pathlib import PurePosixPath
+
+SOPS_META_PREFIXES = ("sops_", "#")
+
+
+def fail(msg: str) -> None:
+    print(msg, file=sys.stderr)
+    sys.exit(2)
+
+
+def new_content(tool_name: str, tool_input: dict) -> str:
+    if tool_name == "Write":
+        return tool_input.get("content", "")
+    if tool_name == "Edit":
+        return tool_input.get("new_string", "")
+    if tool_name == "MultiEdit":
+        return "\n".join(e.get("new_string", "") for e in tool_input.get("edits", []))
+    return ""
+
+
+def check_secrets_env(path: PurePosixPath, content: str) -> None:
+    if not (path.name.startswith("secrets") and path.suffix == ".env"):
+        return
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith(SOPS_META_PREFIXES):
+            continue
+        if "=" not in stripped:
+            continue
+        key, value = stripped.split("=", 1)
+        if key.strip().startswith("sops"):
+            continue
+        if not value.strip().startswith("ENC["):
+            fail(
+                f"Blocked: {path} may only contain SOPS-encrypted values. "
+                f"Line for key '{key.strip()}' is not ENC[...]. Encrypt with "
+                "sops instead of writing plaintext secrets."
+            )
+
+
+def check_layer_separation(path: PurePosixPath, content: str) -> None:
+    parts = path.parts
+    if "kubernetes" in parts and path.suffix == ".tf":
+        fail(
+            "Blocked: Terraform files do not belong under kubernetes/. "
+            "Terraform lives in tf/ (see CLAUDE.md)."
+        )
+    if "tf" in parts and path.suffix in (".yaml", ".yml"):
+        if re.search(r"^\s*apiVersion\s*:", content, re.M) and re.search(
+            r"^\s*kind\s*:", content, re.M
+        ):
+            fail(
+                "Blocked: this looks like a Kubernetes manifest, which does "
+                "not belong under tf/. Kubernetes manifests live in "
+                "kubernetes/ (see CLAUDE.md)."
+            )
+
+
+def main() -> None:
+    data = json.load(sys.stdin)
+    tool_input = data.get("tool_input", {})
+    file_path = tool_input.get("file_path")
+    if not file_path:
+        return
+    path = PurePosixPath(file_path)
+    content = new_content(data.get("tool_name", ""), tool_input)
+    check_secrets_env(path, content)
+    check_layer_separation(path, content)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,24 @@
 {
-  "rules": [
-    "Never write plaintext secrets to any file. All secrets are SOPS-encrypted. Source files are secrets.env, secrets.prod.env, and secrets.stage.env at the repo root.",
-    "tf/infra/singletons/ is global and has no staging equivalent. Changes apply to live production immediately — always plan carefully before applying.",
-    "Kubernetes manifests live in /kubernetes. Terraform lives in /tf. Keep them separate — do not add K8s resources to /tf or Terraform resources to /kubernetes."
-  ]
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/protect-files.py"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/guard-singletons-apply.sh"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,14 @@ graph LR
 
 `singletons` is **global/production only** — no staging equivalent, changes are live immediately.
 
+## Hard rules
+
+These are also enforced by PreToolUse hooks in `.claude/settings.json` (the previous `"rules"` key there was not a real Claude Code setting and was silently ignored):
+
+- **Never write plaintext secrets to any file.** All secrets are SOPS-encrypted; source files are `secrets.env`, `secrets.prod.env`, and `secrets.stage.env` at the repo root. The hook blocks non-`ENC[...]` values in those files.
+- **`tf/infra/singletons/` applies to live production immediately.** Always plan first; the hook forces a user confirmation on any `tofu`/`terraform apply` that mentions singletons.
+- **Kubernetes manifests live in `/kubernetes`, Terraform in `/tf`.** The hook blocks `.tf` files under `kubernetes/` and K8s manifests under `tf/`.
+
 ## Naming conventions
 
 - Resource names: `snake_case`, environment-qualified where needed (e.g. `cloudflare_record.staging_gpo_ca`)


### PR DESCRIPTION
Part of the agentic-setup review across GPO repos.

## Problem

`.claude/settings.json` used a `"rules"` key that is not part of the Claude Code settings schema. The schema allows unknown keys, so nothing errored — all three safety rules were silently ignored.

## Fix

Instructions moved to CLAUDE.md (where they actually load), and each rule is now mechanically enforced by PreToolUse hooks:

| Rule | Enforcement |
|---|---|
| No plaintext secrets in `secrets*.env` | `protect-files.py` blocks any Write/Edit putting a non-`ENC[...]` value into those files |
| `tf/infra/singletons` is live production | `guard-singletons-apply.sh` forces a user confirmation (`permissionDecision: ask`) on any `tofu`/`terraform apply` mentioning singletons, even in auto-accept sessions |
| K8s in `/kubernetes`, Terraform in `/tf` | `protect-files.py` blocks `.tf` under `kubernetes/` and blocks YAML under `tf/` when it contains `apiVersion:` + `kind:` (Helm values files still pass) |

## Validation

All ten cases exercised with simulated hook payloads: three block cases block with actionable messages, allow cases (ENC values, Helm values under tf/, normal .tf, `tofu plan` on singletons, `apply` elsewhere) pass through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wucnc7eo6GpirHruYUa7ep

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wucnc7eo6GpirHruYUa7ep)_