### PR TITLE
Add ontariogreens.ca Cloudflare zone and DNS records

### DIFF
--- a/tf/infra/singletons/cloudflare_ontariogreens.tf
+++ b/tf/infra/singletons/cloudflare_ontariogreens.tf
@@ -1,0 +1,50 @@
+# ontariogreens.ca — migrated from prior registrar/DNS host
+
+resource "cloudflare_zone" "ontariogreens_ca" {
+  account_id = data.sops_file.secrets.data["cloudflare_account_id"]
+  zone       = "ontariogreens.ca"
+}
+
+resource "cloudflare_record" "ontariogreens_ca" {
+  zone_id = cloudflare_zone.ontariogreens_ca.id
+  name    = "ontariogreens.ca"
+  content = "24.199.64.246"
+  type    = "A"
+  ttl     = 1
+  proxied = true
+}
+
+resource "cloudflare_record" "www_ontariogreens_ca" {
+  zone_id = cloudflare_zone.ontariogreens_ca.id
+  name    = "www.ontariogreens.ca"
+  content = "24.199.64.246"
+  type    = "A"
+  ttl     = 1
+  proxied = true
+}
+
+resource "cloudflare_record" "staging_ontariogreens_ca" {
+  zone_id = cloudflare_zone.ontariogreens_ca.id
+  name    = "staging.ontariogreens.ca"
+  content = "134.209.128.228"
+  type    = "A"
+  ttl     = 1
+  proxied = true
+}
+
+# DNS-only: points at another provider's CDN, so it shouldn't be double-proxied
+resource "cloudflare_record" "files_ontariogreens_ca" {
+  zone_id = cloudflare_zone.ontariogreens_ca.id
+  name    = "files.ontariogreens.ca"
+  content = "gpo-files.nyc3.cdn.digitaloceanspaces.com"
+  type    = "CNAME"
+  ttl     = 300
+}
+
+resource "cloudflare_record" "facebook_domain_verification_ontariogreens_ca" {
+  zone_id = cloudflare_zone.ontariogreens_ca.id
+  name    = "ontariogreens.ca"
+  content = "facebook-domain-verification=4ltuf6o3yrf9cq4506sbpol8wt7mtn"
+  type    = "TXT"
+  ttl     = 300
+}

--- a/tf/infra/singletons/github_repos.tf
+++ b/tf/infra/singletons/github_repos.tf
@@ -6,7 +6,6 @@ resource "github_repository" "secure_gpo_ca" {
   allow_merge_commit     = false
   allow_rebase_merge     = true
   delete_branch_on_merge = true
-  has_downloads          = true
   has_issues             = true
   vulnerability_alerts   = true
   has_projects           = true
@@ -26,7 +25,6 @@ resource "github_repository" "gpo_ca" {
   allow_merge_commit     = false
   allow_rebase_merge     = false
   delete_branch_on_merge = true
-  has_downloads          = true
   has_issues             = true
   has_projects           = true
   vulnerability_alerts   = true
@@ -43,7 +41,6 @@ resource "github_repository" "public" {
   name                 = "public"
   description          = "READMEs, Roadmap, and general onboarding information"
   visibility           = "public"
-  has_downloads        = true
   has_issues           = true
   has_projects         = true
   vulnerability_alerts = true
@@ -62,7 +59,6 @@ resource "github_repository" "gpo_platform_configs" {
   visibility             = "public"
   has_projects           = true
   has_issues             = true
-  has_downloads          = true
   allow_auto_merge       = true
   allow_merge_commit     = false
   allow_rebase_merge     = false
@@ -78,12 +74,11 @@ resource "github_branch_default" "gpo_platform_configs" {
 #---
 
 resource "github_repository" "gpo_it" {
-  name          = "gpo-it"
-  description   = "google workspace and future SAML config"
-  visibility    = "private"
-  has_downloads = true
-  has_issues    = true
-  has_projects  = true
+  name         = "gpo-it"
+  description  = "google workspace and future SAML config"
+  visibility   = "private"
+  has_issues   = true
+  has_projects = true
 }
 
 resource "github_branch_default" "gpo_it" {
@@ -94,11 +89,10 @@ resource "github_branch_default" "gpo_it" {
 #---
 
 resource "github_repository" "civicrm_api" {
-  name          = "civicrm-api"
-  description   = "JavaScript (and TypeScript) client for CiviCRM API v4"
-  visibility    = "public"
-  has_downloads = true
-  has_projects  = true
+  name         = "civicrm-api"
+  description  = "JavaScript (and TypeScript) client for CiviCRM API v4"
+  visibility   = "public"
+  has_projects = true
 }
 
 resource "github_branch_default" "civicrm_api" {
@@ -111,7 +105,6 @@ resource "github_branch_default" "civicrm_api" {
 resource "github_repository" "open_walk_sheets" {
   name                 = "open-walk-sheets"
   visibility           = "public"
-  has_downloads        = true
   has_issues           = true
   has_projects         = true
   vulnerability_alerts = true
@@ -128,7 +121,6 @@ resource "github_branch_default" "open_walk_sheets" {
 resource "github_repository" "dot_github" {
   name                 = ".github"
   visibility           = "public"
-  has_downloads        = true
   has_issues           = true
   has_projects         = true
   has_wiki             = true
@@ -146,7 +138,6 @@ resource "github_repository" "migrate_bitbucket_to_github" {
   name                 = "migrate_bitbucket_to_github"
   description          = "Simple Script for migrating repos from bitbucket to github"
   visibility           = "public"
-  has_downloads        = true
   has_issues           = true
   has_projects         = true
   has_wiki             = true
@@ -161,8 +152,7 @@ resource "github_branch_default" "migrate_bitbucket_to_github" {
 #---
 
 resource "github_repository" "cdn_tax_receipts" {
-  name          = "CDNTaxReceipts"
-  visibility    = "public"
-  has_downloads = true
-  has_projects  = true
+  name         = "CDNTaxReceipts"
+  visibility   = "public"
+  has_projects = true
 }


### PR DESCRIPTION
## Summary
- Migrates ontariogreens.ca from its prior DNS host to Cloudflare: new zone plus A records for apex/`www`/`staging`, a CNAME for `files` to the existing DigitalOcean Spaces CDN, and the Facebook domain-verification TXT record.
- Apex/`www`/`staging` A records are proxied (orange cloud); `files` CNAME is DNS-only since it already points at another CDN.
- Removes the `has_downloads` attribute from all `github_repository` resources in `github_repos.tf` — it was drifted (`true` in config vs. `false` actually set on GitHub) and controls a defunct GitHub feature, so the config now just matches reality instead of re-asserting a value.

## Test plan
- [x] `tofu fmt` clean
- [x] `tofu validate` passes
- [x] `tofu plan` reviewed: 6 creates (zone + 5 records) match intent, no unexpected diffs after the `has_downloads` fix
- [ ] `tofu apply` after merge, then verify nameserver cutover at the registrar and confirm the site resolves through Cloudflare