### PR TITLE
Document the plan-then-apply tofu workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,3 +43,4 @@ graph LR
 | Stack boundaries and remote state wiring | [docs/stacks-and-state.md](docs/stacks-and-state.md) |
 | Add a new application | [docs/app-layer.md](docs/app-layer.md) |
 | Bootstrap a new cloud account | [docs/bootstrap.md](docs/bootstrap.md) |
+| Plan/apply workflow | [docs/stacks-and-state.md](docs/stacks-and-state.md) |

--- a/docs/stacks-and-state.md
+++ b/docs/stacks-and-state.md
@@ -21,3 +21,14 @@ Dependency order: `bootstrap` → `infra` → `app`. Singletons have no dependen
 ## tofu-all
 
 Repo root has a `tofu-all` helper script to run a command across all stacks at once.
+
+## Plan and apply
+
+Always save the plan and apply that exact file, rather than running a bare `tofu apply` (which re-plans on its own and can apply something other than what was reviewed):
+
+```bash
+tofu plan -out=plan
+tofu apply plan
+```
+
+Before applying, check the plan for changes unrelated to what you're working on — drift in other resources (e.g. a setting that was changed outside Terraform) will show up in the same plan. Apply it separately or fix the config to match reality instead of bundling it into an unrelated change.


### PR DESCRIPTION
## Summary
- Adds a "Plan and apply" section to `docs/stacks-and-state.md`: always `tofu plan -out=plan` then `tofu apply plan`, plus a note to check the plan for unrelated drift before applying.
- Links it from the `CLAUDE.md` doc index.