### PR TITLE
Redirect ontariogreens.ca to gpo.ca

### DIFF
--- a/tf/infra/singletons/cloudflare_ontariogreens.tf
+++ b/tf/infra/singletons/cloudflare_ontariogreens.tf
@@ -5,10 +5,13 @@ resource "cloudflare_zone" "ontariogreens_ca" {
   zone       = "ontariogreens.ca"
 }
 
+# No real origin — apex and www just terminate at Cloudflare's edge so the
+# redirect ruleset below can fire. 192.0.2.1 is a documentation-only address
+# (RFC 5737); it's never dialed because proxied traffic never reaches origin.
 resource "cloudflare_record" "ontariogreens_ca" {
   zone_id = cloudflare_zone.ontariogreens_ca.id
   name    = "ontariogreens.ca"
-  content = "24.199.64.246"
+  content = "192.0.2.1"
   type    = "A"
   ttl     = 1
   proxied = true
@@ -17,19 +20,36 @@ resource "cloudflare_record" "ontariogreens_ca" {
 resource "cloudflare_record" "www_ontariogreens_ca" {
   zone_id = cloudflare_zone.ontariogreens_ca.id
   name    = "www.ontariogreens.ca"
-  content = "24.199.64.246"
+  content = "192.0.2.1"
   type    = "A"
   ttl     = 1
   proxied = true
 }
 
-resource "cloudflare_record" "staging_ontariogreens_ca" {
+# 301 apex and www -> gpo.ca, preserving path and query string
+resource "cloudflare_ruleset" "ontariogreens_ca_redirect" {
   zone_id = cloudflare_zone.ontariogreens_ca.id
-  name    = "staging.ontariogreens.ca"
-  content = "134.209.128.228"
-  type    = "A"
-  ttl     = 1
-  proxied = true
+  name    = "Redirect to gpo.ca"
+  kind    = "zone"
+  phase   = "http_request_dynamic_redirect"
+
+  rules {
+    action      = "redirect"
+    expression  = "(http.host eq \"ontariogreens.ca\") or (http.host eq \"www.ontariogreens.ca\")"
+    description = "301 ontariogreens.ca / www.ontariogreens.ca -> gpo.ca"
+    enabled     = true
+
+    action_parameters {
+      from_value {
+        status_code           = 301
+        preserve_query_string = true
+
+        target_url {
+          expression = "concat(\"https://gpo.ca\", http.request.uri.path)"
+        }
+      }
+    }
+  }
 }
 
 # DNS-only: points at another provider's CDN, so it shouldn't be double-proxied


### PR DESCRIPTION
## Summary
- `ontariogreens.ca` and `www.ontariogreens.ca` no longer point at the DigitalOcean droplet (`24.199.64.246`) — they now terminate at Cloudflare's edge on a placeholder record (`192.0.2.1`, RFC 5737, never dialed since proxied traffic doesn't reach origin) and 301-redirect to `gpo.ca`, preserving path and query string.
- Drops `staging.ontariogreens.ca` entirely — no origin left for it to point at.
- Leaves `files.ontariogreens.ca` (DO Spaces CDN) and the Facebook domain-verification TXT record untouched.
- Adds a `tf/modules/infra/no_email_dns` module (SPF `-all`, null wildcard DKIM, DMARC `reject`) and applies it to every zone without MX records: `gpotools.ca`, `gpotoolsstage.ca`, `islandgetaway.ca`, and `ontariogreens.ca`. `gpo.ca` is excluded since it sends real mail. This follows Cloudflare's own "Email Record Creator" recommendation for domains that don't send mail, closing off a spoofing vector.

## Test plan
- [x] `tofu fmt` clean
- [x] `tofu validate` passes in `infra/singletons`, `infra/prod`, and `infra/stage`
- [x] `tofu plan` reviewed for all four zones — only the expected creates, no unrelated drift
- [ ] `tofu apply` after merge, then confirm `ontariogreens.ca` / `www.ontariogreens.ca` redirect to `gpo.ca`, `staging.ontariogreens.ca` no longer resolves, and the new TXT records appear in each zone