### PR TITLE
Add no_email_dns module and apply it to domains without mail

### DIFF
--- a/docs/cloudflare-dns.md
+++ b/docs/cloudflare-dns.md
@@ -7,6 +7,8 @@
 | `gpo.ca` | `cloudflare_zone.gpo_ca` | `tf/infra/singletons/cloudflare_domains.tf` |
 | `gpotools.ca` | `cloudflare_zone.gpo_tools` | `tf/infra/prod/cloudflare_zone.tf` |
 | `gpotoolsstage.ca` | `cloudflare_zone.gpo_tools` | `tf/infra/stage/cloudflare_zone.tf` |
+| `islandgetaway.ca` | `cloudflare_zone.islandgetaway_ca` | `tf/infra/singletons/cloudflare_islandgetaway.tf` |
+| `ontariogreens.ca` | `cloudflare_zone.ontariogreens_ca` | `tf/infra/singletons/cloudflare_ontariogreens.tf` |
 
 `gpo.ca` is global/production — no staging equivalent.
 
@@ -28,3 +30,17 @@
 ## Redirect rules
 
 Use `cloudflare_ruleset` with `phase = "http_request_dynamic_redirect"` and a `locals {}` toggle. See `tf/infra/singletons/cloudflare_april_fools.tf` for a working example.
+
+## Domains that don't send mail
+
+Use the `tf/modules/infra/no_email_dns` module to add anti-spoofing records (SPF `-all`, a null wildcard DKIM, and a DMARC `reject` policy) for any zone that has no MX records:
+
+```hcl
+module "example_ca_no_email" {
+  source  = "../../modules/infra/no_email_dns"
+  zone_id = cloudflare_zone.example_ca.id
+  domain  = "example.ca"
+}
+```
+
+Skip it for `gpo.ca`, which sends real mail (Google Workspace, SendGrid, Brevo).

--- a/tf/infra/prod/cloudflare_zone.tf
+++ b/tf/infra/prod/cloudflare_zone.tf
@@ -3,3 +3,9 @@ resource "cloudflare_zone" "gpo_tools" {
   account_id = data.sops_file.secrets.data["cloudflare_account_id"]
   zone       = "gpotools.ca"
 }
+
+module "gpo_tools_no_email" {
+  source  = "../../modules/infra/no_email_dns"
+  zone_id = cloudflare_zone.gpo_tools.id
+  domain  = "gpotools.ca"
+}

--- a/tf/infra/singletons/cloudflare_islandgetaway.tf
+++ b/tf/infra/singletons/cloudflare_islandgetaway.tf
@@ -9,6 +9,12 @@ resource "cloudflare_zone" "islandgetaway_ca" {
   zone       = "islandgetaway.ca"
 }
 
+module "islandgetaway_ca_no_email" {
+  source  = "../../modules/infra/no_email_dns"
+  zone_id = cloudflare_zone.islandgetaway_ca.id
+  domain  = "islandgetaway.ca"
+}
+
 # ---------------------------------------------------------------------------
 # Pages project + custom domain
 # ---------------------------------------------------------------------------

--- a/tf/infra/singletons/cloudflare_ontariogreens.tf
+++ b/tf/infra/singletons/cloudflare_ontariogreens.tf
@@ -68,3 +68,9 @@ resource "cloudflare_record" "facebook_domain_verification_ontariogreens_ca" {
   type    = "TXT"
   ttl     = 300
 }
+
+module "ontariogreens_ca_no_email" {
+  source  = "../../modules/infra/no_email_dns"
+  zone_id = cloudflare_zone.ontariogreens_ca.id
+  domain  = "ontariogreens.ca"
+}

--- a/tf/infra/stage/cloudflare_zone.tf
+++ b/tf/infra/stage/cloudflare_zone.tf
@@ -3,3 +3,9 @@ resource "cloudflare_zone" "gpo_tools" {
   account_id = data.sops_file.secrets.data["cloudflare_account_id"]
   zone       = "gpotoolsstage.ca"
 }
+
+module "gpo_tools_no_email" {
+  source  = "../../modules/infra/no_email_dns"
+  zone_id = cloudflare_zone.gpo_tools.id
+  domain  = "gpotoolsstage.ca"
+}

--- a/tf/modules/infra/no_email_dns/main.tf
+++ b/tf/modules/infra/no_email_dns/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
+  }
+}
+
+# Anti-spoofing records for a domain that doesn't send mail: tells receiving
+# mail servers to reject anything claiming to be from it.
+
+resource "cloudflare_record" "spf" {
+  zone_id = var.zone_id
+  name    = var.domain
+  content = "v=spf1 -all"
+  type    = "TXT"
+  ttl     = 300
+}
+
+resource "cloudflare_record" "wildcard_domainkey" {
+  zone_id = var.zone_id
+  name    = "*._domainkey.${var.domain}"
+  content = "v=DKIM1; p="
+  type    = "TXT"
+  ttl     = 300
+}
+
+resource "cloudflare_record" "dmarc" {
+  zone_id = var.zone_id
+  name    = "_dmarc.${var.domain}"
+  content = "v=DMARC1; p=reject; sp=reject; adkim=s; aspf=s;"
+  type    = "TXT"
+  ttl     = 300
+}

--- a/tf/modules/infra/no_email_dns/variables.tf
+++ b/tf/modules/infra/no_email_dns/variables.tf
@@ -1,0 +1,9 @@
+variable "zone_id" {
+  description = "Cloudflare zone ID the records belong to"
+  type        = string
+}
+
+variable "domain" {
+  description = "Full apex domain, e.g. \"example.ca\""
+  type        = string
+}


### PR DESCRIPTION
## Summary
- Adds a `tf/modules/infra/no_email_dns` module (SPF `-all`, null wildcard DKIM, DMARC `reject`) following Cloudflare's own "Email Record Creator" recommendation for domains that don't send mail — closes off a spoofing vector.
- Applies it to every zone with no MX records: `gpotools.ca`, `gpotoolsstage.ca`, `islandgetaway.ca`, and `ontariogreens.ca`. `gpo.ca` is excluded since it sends real mail.
- Documents the module in `docs/cloudflare-dns.md`.

## Test plan
- [x] `tofu fmt` clean
- [x] `tofu validate` passes in `infra/singletons`, `infra/prod`, and `infra/stage`
- [x] `tofu plan` reviewed for all four zones — only the expected 3 TXT record creates per zone, no unrelated drift
- [ ] `tofu apply` after merge, then confirm the SPF/DKIM/DMARC TXT records appear in each zone