### PR TITLE
Harden Cloudflare protection for WordPress admin/login routes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ graph LR
 |---|---|
 | Add or change DNS records / zones | [docs/cloudflare-dns.md](docs/cloudflare-dns.md) |
 | Deploy a Cloudflare Pages site | [docs/cloudflare-pages.md](docs/cloudflare-pages.md) |
+| WAF custom rules, rate limiting, bot protection | [docs/cloudflare-waf.md](docs/cloudflare-waf.md) |
 | Create or configure a GitHub repository | [docs/github-repos.md](docs/github-repos.md) |
 | GKE, GCP projects, Artifact Registry | [docs/gke-and-gcp.md](docs/gke-and-gcp.md) |
 | EKS, VPC, ECR | [docs/aws-eks.md](docs/aws-eks.md) |

--- a/docs/cloudflare-waf-design.md
+++ b/docs/cloudflare-waf-design.md
@@ -1,0 +1,307 @@
+# Cloudflare WAF rules: design doc
+
+Issue: [#202](https://github.com/gpo/gpo-platform-configs/issues/202)
+
+## Context
+
+gpo.ca is a Bedrock-style WordPress install where WP core lives under
+`/wordpress/` (`WP_SITEURL=https://gpo.ca/wordpress`). The same Cloudflare
+zone also serves `secure.gpo.ca`, a Drupal + CiviCRM site with a completely
+different admin surface. The zone is on the Cloudflare Free plan.
+
+This doc covers how to write Cloudflare edge rules for the WordPress site
+only. `secure.gpo.ca` needs its own ruleset and is out of scope here.
+
+## Goals
+
+1. **Reduce the attack surface that ships with WordPress by default.** Block
+   or challenge paths that are unused but routinely probed (xmlrpc, comments,
+   signup, user enumeration). The intent is defence in depth: even if origin
+   code already disables a feature, blocking it at the edge eliminates a class
+   of future regressions (e.g., a plugin re-enabling XML-RPC).
+2. **Raise the cost of credential stuffing against `/wp-login.php`.** Rate
+   limiting and managed challenges make brute-force attacks slow and
+   expensive without affecting the small number of legitimate staff logins.
+3. **Block known-dangerous upload patterns.** The Bedrock layout puts media at
+   `/uploads/` with no `.htaccess` PHP execution guard, so an upload-to-RCE
+   chain is the highest-impact exploit to prevent at the edge.
+4. **Make the rule set auditable from source.** Every rule should trace back
+   to a verified fact about the `gpo/gpo-ca` codebase, not a generic
+   WordPress hardening checklist.
+
+## Non-goals
+
+- **Protecting `secure.gpo.ca`.** Different application, different admin
+  surface (`/user/login`, `/civicrm/*`), needs its own design.
+- **Replacing origin-level security.** Cloudflare rules are a layer, not a
+  substitute. `.htaccess` rules, `DISALLOW_FILE_MODS`, and application-level
+  auth remain the primary controls.
+- **Full allowlist at the edge.** An allowlist ("block everything except known
+  good paths") would be the strongest posture, but it's impractical without
+  a complete inventory of every URL the front end and third-party plugins
+  serve. See Option C below.
+- **Rate limiting CiviCRM write endpoints.** The unauthenticated
+  `/wp-json/gpo-action-blocks/v1/*` and `/api/*.php` endpoints are arguably
+  a higher-value target than the login page, but rate limiting them is
+  blocked on the Free-plan rule budget (1 rate-limit rule allowed). Tracked
+  as an open item.
+- **Origin lockdown.** Restricting the origin server to accept connections
+  only from Cloudflare IPs (Authenticated Origin Pulls, or firewall rules)
+  is important but orthogonal to WAF rule design. Origin IPs are currently
+  in plaintext in `cloudflare_domains.tf`.
+
+## Constraints
+
+### Cloudflare Free plan limits
+
+| Resource | Free-plan limit |
+|---|---|
+| Custom WAF rules (`http_request_firewall_custom`) | 5 |
+| Rate-limiting rules (`http_ratelimit`) | 1 |
+| Bot Fight Mode | available (basic) |
+| Super Bot Fight Mode (`sbfm_*`, `optimize_wordpress`) | Pro+ only |
+| Cloudflare Access (Zero Trust) | requires separate plan |
+
+The current implementation uses exactly 5 WAF rules and 1 rate-limit rule,
+which means **the Free plan is fully consumed**. Adding any new rule requires
+either upgrading the plan, consolidating existing rules, or moving logic to
+the origin.
+
+### Bedrock layout
+
+WP core is at `/wordpress/`, so the real admin surface is
+`/wordpress/wp-admin/` and `/wordpress/wp-login.php`. The bare `/wp-*` paths
+don't serve anything, but `.htaccess` routes unknown paths into `index.php`,
+costing a PHP bootstrap per probe. Rules match both path variants.
+
+### `admin-ajax.php` must stay open
+
+Third-party plugins (Gravity Forms, Popup Maker, TotalContest) are
+Composer-installed and gitignored. Their front-end AJAX use can't be ruled
+out from the repo. Challenging `admin-ajax.php` risks breaking public-facing
+forms.
+
+### `wp-cron.php` must stay open
+
+`DISABLE_WP_CRON` is not set and there's no system cron. WordPress spawns
+cron via a loopback request to `WP_SITEURL`, which resolves through
+Cloudflare. Blocking it would silently break scheduled jobs.
+
+### Singletons stack is production-only
+
+The `tf/infra/singletons` stack has no staging equivalent. Every `tofu apply`
+changes the live zone. Rules must be conservative, and new rules should be
+deployed `enabled = false` first where practical.
+
+### Shared zone with `secure.gpo.ca`
+
+Zone-wide settings (Bot Fight Mode) affect both sites. Hostname-scoped rules
+must use `http.host eq "gpo.ca"` or path prefixes that don't collide with
+Drupal routes.
+
+## What's already verified against `gpo/gpo-ca` source
+
+These facts were confirmed by reading the codebase, not assumed from a
+generic checklist:
+
+| Feature | Status | Source |
+|---|---|---|
+| XML-RPC | Not disabled in code, nothing calls it | No `add_filter('xmlrpc_enabled', ...)` found |
+| Comments | `comments_open` filtered to `__return_false` | `functions.php:2505` |
+| RSS/Atom feeds | All `do_feed*` hooks exit early | `functions.php:2170-2196` |
+| Public registration | No public signup; staff-only accounts | No registration form in theme |
+| REST users endpoint | Not used by front end | Only REST namespace used: `gpo-action-blocks/v1` |
+| Author archives | Not linked anywhere in theme | No `?author=` links |
+| `is_user_logged_in` in theme | Not present | Grep confirms zero matches |
+| `.htaccess` PHP guards | Blocks `wp-config.php`, `readme.html`, dotfiles, `repair.php`, `wp-mail.php`, `wp-includes/*.php`, TRACE/TRACK/DELETE | `web/.htaccess` |
+| `.htaccess` uploads guard | **Missing** | No rule preventing PHP execution under `/uploads/` |
+| `DISALLOW_FILE_MODS` | Set on production | `wp-config.php:47-49` |
+| `DISABLE_WP_CRON` | **Not set** | Grep confirms zero matches |
+
+## Options
+
+### Option A: denylist in platform-configs (current PR #203)
+
+Keep the rules in `tf/infra/singletons/` as a denylist: block/challenge
+specific known-bad paths, leave everything else open.
+
+**What's in the current implementation:**
+
+| # | Rule | Action |
+|---|---|---|
+| 1 | Unused endpoints (xmlrpc, comments, signup, trackback) | block |
+| 2 | User enumeration (REST users, `?author=N`) | block |
+| 3 | Admin/login surfaces (with `admin-ajax.php` excluded) | managed_challenge |
+| 4 | PHP execution under `/uploads/` | block |
+| 5 | Non-CA traffic to admin (disabled by default) | managed_challenge |
+| R1 | POST `/wp-login.php` rate limit (5/min/IP, 10min block) | block |
+
+**Pros:**
+
+- Already implemented and reviewed against the actual codebase.
+- Conservative: won't break anything that works today.
+- Lives in the infra repo where other Cloudflare config already lives
+  (DNS, Pages, zones).
+- Rules are auditable via the same PR/review process as other infra changes.
+
+**Cons:**
+
+- Denylist is inherently incomplete. New WordPress features, plugin routes,
+  or overlooked paths won't be covered until someone adds a rule.
+- Coupled to knowledge of the WordPress codebase. When `gpo-ca` changes
+  (new plugin, new endpoint), the rules here may need updating, but nothing
+  enforces that.
+- Free-plan ceiling is already hit. No room for the CiviCRM rate-limit rule
+  or any new protection without consolidation or a plan upgrade.
+
+**When to pick this:** The threat model is "block the known-bad stuff that
+scanners hit" and the team accepts that new attack surface from future
+WordPress/plugin changes won't be covered at the edge until manually added.
+
+### Option B: denylist in `gpo-ca` repo, deployed via CI
+
+Move the Cloudflare rules into the `gpo/gpo-ca` repo (as a Terraform module
+or a standalone config), deployed by `gpo-ca`'s CI pipeline. The
+platform-configs repo would still own the zone and DNS, but the WAF rules
+would live alongside the application code.
+
+**Pros:**
+
+- Rules and the code they protect are in the same repo. A PR that adds a
+  plugin can also update the WAF rules.
+- Developers working on `gpo-ca` can see and modify the rules without
+  touching the infra repo.
+- Easier to keep rules in sync with the application.
+
+**Cons:**
+
+- Requires wiring Cloudflare provider credentials into `gpo-ca` CI, which
+  currently only deploys application code.
+- Splits Cloudflare config across two repos (zone/DNS in platform-configs,
+  WAF in gpo-ca). Debugging requires checking both.
+- The `gpo-ca` repo has no Terraform/OpenTofu setup today; this would be
+  a new capability to introduce and maintain.
+- Still a denylist with the same incompleteness problem.
+
+**When to pick this:** The team frequently changes plugins or endpoints and
+wants WAF rules reviewed in the same PR as the application change.
+
+### Option C: origin-level allowlist (`.htaccess` or nginx)
+
+Instead of (or in addition to) Cloudflare rules, enforce an allowlist at the
+origin. Only serve paths that match known routes; return 403 for everything
+else. This could be done in `.htaccess` (already used) or by switching to
+nginx (the DDEV config already uses nginx).
+
+**Pros:**
+
+- Strongest security posture: unknown paths are denied by default.
+- Not constrained by Cloudflare rule limits.
+- Lives in the application repo, naturally versioned with the code.
+- Catches internal requests (loopback, cron) that bypass Cloudflare.
+
+**Cons:**
+
+- Hard to build a complete allowlist. WordPress core, plugins, and themes
+  register routes dynamically. Missing a legitimate path breaks
+  functionality silently.
+- Every PHP bootstrap to serve a 403 still costs CPU. Cloudflare rules
+  avoid this by rejecting at the edge.
+- Composer-installed plugins are gitignored, so their routes aren't visible
+  in the repo. Building the allowlist requires runtime inspection of a
+  running site (e.g., `wp route list`, REST API discovery).
+- Ongoing maintenance burden: every new plugin, block, or endpoint needs an
+  allowlist update.
+
+**When to pick this:** The site is stable, plugins change rarely, and the
+team is willing to invest in building and maintaining a comprehensive route
+inventory.
+
+### Option D: hybrid (recommended)
+
+Use Cloudflare for **infra-level protections** that don't depend on
+application knowledge, and handle **application-aware restrictions** at the
+origin or via CI-deployed rules.
+
+**In platform-configs (Cloudflare, infra-level):**
+
+- Bot Fight Mode (zone-wide, no rule budget cost)
+- Block PHP execution under `/uploads/` (universally dangerous, unlikely to
+  change)
+- Rate limit POST to login paths (generic anti-brute-force)
+- Managed challenge on admin/login surfaces (protects all WordPress admin
+  paths)
+
+**In `gpo-ca` or as follow-up issues:**
+
+- Block/allow specific endpoints (xmlrpc, comments, signup, REST users) via
+  `.htaccess` or application code, since these depend on what the app
+  actually uses
+- Rate limit CiviCRM write endpoints at the origin (not constrained by
+  Free-plan limits)
+- Fix the `X-Forwarded-For` trust bug in `class.gpo.utils.php` so
+  origin-level rate limiting works correctly
+- Add `.htaccess` PHP execution guard for `/uploads/` as defence in depth
+  (belt and suspenders with the Cloudflare rule)
+
+**Pros:**
+
+- Separates concerns: infra rules are stable and don't need application
+  knowledge; application rules live with the application.
+- Frees Cloudflare rule budget for the protections that genuinely benefit
+  from edge enforcement (rate limiting, upload blocking, bot challenges).
+- Application-specific blocks (xmlrpc, comments, user enum) can be more
+  easily maintained where the context is.
+- Unblocks CiviCRM endpoint protection without waiting for a plan upgrade.
+
+**Cons:**
+
+- Two places to look for security rules.
+- Requires work in `gpo-ca` repo (`.htaccess` changes, XFF fix) that's
+  outside the scope of this issue.
+- Origin-level blocks still cost a PHP bootstrap (for paths that
+  `.htaccess` doesn't catch before `index.php`).
+
+**When to pick this:** The team wants the strongest practical posture without
+being blocked on Cloudflare plan limits, and is willing to split the work
+across repos.
+
+## Recommendation
+
+**Option D (hybrid)**, implemented in two phases:
+
+**Phase 1** (this PR, platform-configs): Trim the current ruleset to the 4
+infra-level rules that don't depend on application knowledge:
+
+1. Managed challenge on admin/login surfaces
+2. Block PHP under `/uploads/`
+3. Rate limit POST to login paths
+4. Bot Fight Mode (no rule budget cost)
+
+This leaves 1 Free-plan WAF rule slot open for future use (e.g., geo-scoping
+when the travelling-admin process is agreed on).
+
+**Phase 2** (follow-up issues in `gpo-ca`): Move application-specific blocks
+to `.htaccess` and fix the gaps:
+
+- Block xmlrpc, comments, signup, trackback, user enumeration at the origin
+- Add `.htaccess` PHP execution guard for `/uploads/`
+- Fix `X-Forwarded-For` trust bug in `class.gpo.utils.php`
+- Rate limit CiviCRM write endpoints at the origin
+- Investigate `DISABLE_WP_CRON` + system cron to unblock blocking
+  `wp-cron.php` at the edge
+
+## Open questions
+
+1. **What Cloudflare plan is the zone actually on?** The implementation
+   assumes Free. If Pro or higher, Super Bot Fight Mode and additional rule
+   slots are available, which changes the calculus.
+2. **Is the origin IP restricted to Cloudflare ranges?** If not, all edge
+   rules can be bypassed by hitting the origin directly. Origin IPs are in
+   plaintext in `cloudflare_domains.tf`.
+3. **Does `admin-ajax.php` actually receive front-end traffic?** Verifiable
+   by checking Cloudflare analytics or server logs. If not, it can be added
+   to the challenge rule.
+4. **Is a Cloudflare plan upgrade on the table?** Pro unlocks Super Bot Fight
+   Mode (`optimize_wordpress`), more WAF rule slots, and more rate-limit
+   rules, which would let all of Options A through D work more comfortably.

--- a/docs/cloudflare-waf.md
+++ b/docs/cloudflare-waf.md
@@ -4,41 +4,77 @@
 
 Resources: `tf/infra/singletons/cloudflare_wordpress_admin_protection.tf`
 
-Admin/login endpoints on WordPress sites are constantly probed by automated
-scanning and credential-stuffing traffic. Three layers protect them on the
-`gpo.ca` zone, applied by path so they cover every WordPress install sharing
-the zone (`gpo.ca`, `secure.gpo.ca`, and any future subdomain), not just one
-site:
+Rules here were derived from the actual `gpo/gpo-ca` source, not a generic
+WordPress hardening checklist. Two facts about that codebase drive most of
+the design:
+
+- **WP core lives under `/wordpress`.** `WP_SITEURL` is
+  `https://gpo.ca/wordpress`, so the real login is
+  `/wordpress/wp-login.php` and the real admin is `/wordpress/wp-admin/`.
+  Rules matching bare `/wp-login.php` protect nothing. Both forms are
+  matched: the bare paths don't exist, but `web/.htaccess` funnels unknown
+  paths into `index.php`, so blocking scanner probes at the edge saves the
+  origin a PHP bootstrap each time.
+- **`secure.gpo.ca` is Drupal + CiviCRM, not WordPress.** None of these
+  rules protect it. See the open items below.
+
+### Layers
 
 1. **Bot Fight Mode** (`cloudflare_bot_management.gpo_ca`) — zone-wide,
-   available on every Cloudflare plan tier. Challenges traffic Cloudflare
-   identifies as definitely automated.
+   available on every plan tier.
 2. **Rate limiting** (`cloudflare_ruleset.gpo_ca_wp_login_rate_limit`) —
-   blocks a source IP for 10 minutes after 5 POSTs to `/wp-login.php` within
-   60 seconds. Adjust via the `wp_login_rate_limit_*` locals.
-3. **WAF custom rule** (`cloudflare_ruleset.gpo_ca_admin_route_protection`)
-   — issues a managed challenge to any request matching `/wp-login.php`,
-   `/xmlrpc.php`, or `/wp-admin/*`. `/wp-admin/admin-ajax.php` is
-   deliberately excluded: plugins (contact forms, WooCommerce, etc.) call it
-   from the public-facing, unauthenticated site, so challenging it would
-   break normal visitor traffic.
+   blocks a source IP for 10 minutes after 5 POSTs to the login path in 60
+   seconds. Tunable via the `wp_login_rate_limit_*` locals.
+3. **WAF custom rules** (`cloudflare_ruleset.gpo_ca_admin_route_protection`):
+
+   | Rule | Action | Why it's safe |
+   |---|---|---|
+   | Unused endpoints: `xmlrpc.php`, `wp-comments-post.php`, `wp-signup.php`, `wp-register.php`, `/trackback` | block | XML-RPC isn't disabled anywhere in code and nothing calls it; `comments_open` is filtered to `__return_false` site-wide; there's no public registration |
+   | User enumeration: `/wp-json/wp/v2/users`, `?author=<id>` | block | The only REST namespace the front end uses is `gpo-action-blocks/v1`; the theme never queries users or author archives |
+   | PHP under `/uploads/` | block | `CONTENT_DIR` is `""` so media sits at `/uploads`, and `web/.htaccess` has no PHP-execution guard there |
+   | Admin/login surfaces | managed challenge | Front end is fully anonymous — no `is_user_logged_in`/`wp_login_url` anywhere in the theme, so only staff hit these |
+   | Non-CA traffic to admin surfaces | managed challenge | **disabled by default**, see below |
+
+`/wordpress/wp-admin/admin-ajax.php` is deliberately excluded from the admin
+rule. Third-party plugins (Gravity Forms, Popup Maker, TotalContest) are
+Composer-installed rather than vendored, so their front-end AJAX use can't be
+ruled out from the repo. Verify against a running site before tightening.
+
+### Already handled in code — no edge rule needed
+
+Checked and confirmed already disabled in `gpo/gpo-ca`, so adding Cloudflare
+rules for them would be redundant: RSS/Atom feeds (`do_feed*` hooked to an
+early exit), comments, the generator meta tag, emoji scripts, and
+`DISALLOW_FILE_MODS` on production. `web/.htaccess` additionally denies
+`wp-config.php`, `readme.html`, `license.txt`, dotfiles, `repair.php`,
+`wp-mail.php`, `wp-includes/*.php`, and TRACE/TRACK/DELETE methods.
 
 ### Open items
 
-- **Plan tier.** Super Bot Fight Mode (`sbfm_*` fields and
-  `optimize_wordpress` on `cloudflare_bot_management`) requires a Pro plan
-  or above and isn't enabled here because the account's current tier hasn't
-  been confirmed. If the zone is Pro+, add those fields to get
-  WordPress-tuned bot scoring.
-- **Geo-scoping to Canada.** `local.restrict_admin_routes_to_canada` in
-  `cloudflare_wordpress_admin_protection.tf` adds a second WAF rule that
-  issues a managed challenge (not a hard block) to non-CA traffic hitting
-  admin routes, additive to the two layers above. It defaults to `false`.
-  A challenge was chosen over an outright block so a travelling admin can
-  still get through by solving it, standing in for a proper exception
-  process. Before flipping this on:
-  - Confirm this is acceptable as the exception mechanism, or design a
-    dedicated one (e.g. a temporary IP allowlist rule, or a Cloudflare
-    Access policy for admin routes instead of geo-matching).
-  - Decide whether other zones on the account (see
-    [cloudflare-dns.md](cloudflare-dns.md)) need the same treatment.
+- **Plan tier and rule budget.** The custom ruleset is currently 5 rules,
+  which is exactly the Cloudflare Free-plan ceiling, and Free allows only one
+  rate-limiting rule. Confirm the zone's plan before adding more. Pro+ also
+  unlocks Super Bot Fight Mode (`sbfm_*` and `optimize_wordpress` on
+  `cloudflare_bot_management`), which is WordPress-aware and worth enabling.
+- **Unauthenticated CiviCRM write endpoints are unprotected.** Both
+  `/wp-json/gpo-action-blocks/v1/*` (email-action, download-action,
+  call-mpp-action, all `permission_callback => __return_true`) and the
+  `/api/*.php` form handlers create CiviCRM contacts and send mail with no
+  captcha, nonce, or throttle. Turnstile covers Gravity Forms only, not
+  these. This is arguably a higher-value target than the login page and
+  wants its own rate-limit rule — blocked on the plan-tier question above.
+- **`secure.gpo.ca` (Drupal/CiviCRM) has no equivalent protection.** Its
+  admin surfaces are `/user/login`, `/user/password`, and `/civicrm/*`.
+  Needs its own ruleset; the WordPress paths here don't apply.
+- **Don't block `/wp-cron.php` at the edge.** `DISABLE_WP_CRON` isn't set
+  and there's no system cron, so WP spawns cron via a loopback request to
+  `WP_SITEURL` — which resolves through Cloudflare. Blocking it would
+  silently break scheduled jobs. Set `DISABLE_WP_CRON` and move to a real
+  cron (`wp cron event run --due-now`) first, then block it.
+- **Geo-scoping to Canada.** `local.restrict_admin_routes_to_canada` adds a
+  managed challenge (not a hard block) for non-CA traffic to admin routes,
+  additive to the layers above. Defaults to `false`. A challenge was chosen
+  over a block so a travelling admin can still get through, standing in for
+  a proper exception process. Before enabling, confirm that's acceptable or
+  design a dedicated mechanism (temporary IP allowlist, or a Cloudflare
+  Access policy on admin routes instead of geo-matching).

--- a/docs/cloudflare-waf.md
+++ b/docs/cloudflare-waf.md
@@ -1,0 +1,44 @@
+# Cloudflare WAF / bot protection
+
+## WordPress admin/login hardening (gpo.ca zone)
+
+Resources: `tf/infra/singletons/cloudflare_wordpress_admin_protection.tf`
+
+Admin/login endpoints on WordPress sites are constantly probed by automated
+scanning and credential-stuffing traffic. Three layers protect them on the
+`gpo.ca` zone, applied by path so they cover every WordPress install sharing
+the zone (`gpo.ca`, `secure.gpo.ca`, and any future subdomain), not just one
+site:
+
+1. **Bot Fight Mode** (`cloudflare_bot_management.gpo_ca`) — zone-wide,
+   available on every Cloudflare plan tier. Challenges traffic Cloudflare
+   identifies as definitely automated.
+2. **Rate limiting** (`cloudflare_ruleset.gpo_ca_wp_login_rate_limit`) —
+   blocks a source IP for 10 minutes after 5 POSTs to `/wp-login.php` within
+   60 seconds. Adjust via the `wp_login_rate_limit_*` locals.
+3. **WAF custom rule** (`cloudflare_ruleset.gpo_ca_admin_route_protection`)
+   — issues a managed challenge to any request matching `/wp-login.php`,
+   `/xmlrpc.php`, or `/wp-admin/*`. `/wp-admin/admin-ajax.php` is
+   deliberately excluded: plugins (contact forms, WooCommerce, etc.) call it
+   from the public-facing, unauthenticated site, so challenging it would
+   break normal visitor traffic.
+
+### Open items
+
+- **Plan tier.** Super Bot Fight Mode (`sbfm_*` fields and
+  `optimize_wordpress` on `cloudflare_bot_management`) requires a Pro plan
+  or above and isn't enabled here because the account's current tier hasn't
+  been confirmed. If the zone is Pro+, add those fields to get
+  WordPress-tuned bot scoring.
+- **Geo-scoping to Canada.** `local.restrict_admin_routes_to_canada` in
+  `cloudflare_wordpress_admin_protection.tf` adds a second WAF rule that
+  issues a managed challenge (not a hard block) to non-CA traffic hitting
+  admin routes, additive to the two layers above. It defaults to `false`.
+  A challenge was chosen over an outright block so a travelling admin can
+  still get through by solving it, standing in for a proper exception
+  process. Before flipping this on:
+  - Confirm this is acceptable as the exception mechanism, or design a
+    dedicated one (e.g. a temporary IP allowlist rule, or a Cloudflare
+    Access policy for admin routes instead of geo-matching).
+  - Decide whether other zones on the account (see
+    [cloudflare-dns.md](cloudflare-dns.md)) need the same treatment.

--- a/tf/infra/singletons/README.md
+++ b/tf/infra/singletons/README.md
@@ -35,6 +35,7 @@ will *not* have a separate copy for stage and prod belongs here.
 
 | Name | Type |
 |------|------|
+| [cloudflare_bot_management.gpo_ca](https://registry.terraform.io/providers/cloudflare/cloudflare/4.48.0/docs/resources/bot_management) | resource |
 | [cloudflare_pages_domain.april_fools_1997_gpo_ca](https://registry.terraform.io/providers/cloudflare/cloudflare/4.48.0/docs/resources/pages_domain) | resource |
 | [cloudflare_pages_domain.islandgetaway_ca](https://registry.terraform.io/providers/cloudflare/cloudflare/4.48.0/docs/resources/pages_domain) | resource |
 | [cloudflare_pages_project.april_fools](https://registry.terraform.io/providers/cloudflare/cloudflare/4.48.0/docs/resources/pages_project) | resource |
@@ -88,6 +89,8 @@ will *not* have a separate copy for stage and prod belongs here.
 | [cloudflare_record.web_e_gpo_ca](https://registry.terraform.io/providers/cloudflare/cloudflare/4.48.0/docs/resources/record) | resource |
 | [cloudflare_record.www_gpo_ca](https://registry.terraform.io/providers/cloudflare/cloudflare/4.48.0/docs/resources/record) | resource |
 | [cloudflare_record.www_islandgetaway_ca](https://registry.terraform.io/providers/cloudflare/cloudflare/4.48.0/docs/resources/record) | resource |
+| [cloudflare_ruleset.gpo_ca_admin_route_protection](https://registry.terraform.io/providers/cloudflare/cloudflare/4.48.0/docs/resources/ruleset) | resource |
+| [cloudflare_ruleset.gpo_ca_wp_login_rate_limit](https://registry.terraform.io/providers/cloudflare/cloudflare/4.48.0/docs/resources/ruleset) | resource |
 | [cloudflare_ruleset.www_islandgetaway_ca_redirect](https://registry.terraform.io/providers/cloudflare/cloudflare/4.48.0/docs/resources/ruleset) | resource |
 | [cloudflare_zone.gpo_ca](https://registry.terraform.io/providers/cloudflare/cloudflare/4.48.0/docs/resources/zone) | resource |
 | [cloudflare_zone.islandgetaway_ca](https://registry.terraform.io/providers/cloudflare/cloudflare/4.48.0/docs/resources/zone) | resource |

--- a/tf/infra/singletons/cloudflare_wordpress_admin_protection.tf
+++ b/tf/infra/singletons/cloudflare_wordpress_admin_protection.tf
@@ -1,12 +1,17 @@
-# Harden Cloudflare-level protection for WordPress admin/login surfaces on
-# the gpo.ca zone (gpo.ca, secure.gpo.ca, and any future WordPress site
-# sharing this zone). See docs/cloudflare-waf.md for rationale, threshold
-# choices, and the exception process for admins travelling outside Canada.
+# Harden Cloudflare-level protection for the WordPress site at gpo.ca.
+#
+# Scoped to the gpo.ca WordPress install specifically. secure.gpo.ca is a
+# Drupal + CiviCRM site on the same zone with a completely different admin
+# surface (/user/login, /civicrm/*) and is NOT covered by these rules.
+#
+# Paths and exclusions here were derived from the gpo/gpo-ca source rather
+# than a generic WordPress checklist — see docs/cloudflare-waf.md for what
+# was verified, what's already handled in code, and the open items.
 #
 # https://github.com/gpo/gpo-platform-configs/issues/202
 
 locals {
-  # Requests per source IP per minute allowed to POST /wp-login.php before
+  # Requests per source IP per minute allowed to POST the login form before
   # Cloudflare starts blocking that IP.
   wp_login_rate_limit_requests_per_minute = 5
   wp_login_rate_limit_block_seconds       = 600
@@ -16,10 +21,20 @@ locals {
   # agreed on before it's safe to flip on.
   restrict_admin_routes_to_canada = false
 
-  # admin-ajax.php lives under /wp-admin but is called by unauthenticated
-  # front-end visitors (contact forms, WooCommerce, etc.), so it's excluded
-  # from admin-route matching to avoid challenging normal site traffic.
-  wp_admin_route_expression = "((http.request.uri.path eq \"/wp-login.php\") or (http.request.uri.path eq \"/xmlrpc.php\") or (starts_with(http.request.uri.path, \"/wp-admin\") and http.request.uri.path ne \"/wp-admin/admin-ajax.php\"))"
+  # gpo-ca is a Bedrock-style install: WP core lives under /wordpress
+  # (WP_SITEURL=https://gpo.ca/wordpress), so the real admin surface is
+  # /wordpress/wp-admin and the real login is /wordpress/wp-login.php.
+  # The bare /wp-* paths are matched too — nothing serves them, but scanners
+  # hammer them constantly and .htaccess routes unknown paths into index.php,
+  # so matching at the edge saves the origin a PHP bootstrap per probe.
+  #
+  # admin-ajax.php is excluded: third-party plugins (Gravity Forms, Popup
+  # Maker, TotalContest) are Composer-installed rather than vendored into the
+  # repo, so their front-end AJAX use can't be ruled out from source. Leaving
+  # it unchallenged is the conservative choice.
+  wp_admin_route_expression = "((http.request.uri.path eq \"/wordpress/wp-login.php\") or (http.request.uri.path eq \"/wp-login.php\") or (starts_with(http.request.uri.path, \"/wordpress/wp-admin\") and http.request.uri.path ne \"/wordpress/wp-admin/admin-ajax.php\") or (starts_with(http.request.uri.path, \"/wp-admin\") and http.request.uri.path ne \"/wp-admin/admin-ajax.php\"))"
+
+  wp_login_path_expression = "((http.request.uri.path eq \"/wordpress/wp-login.php\") or (http.request.uri.path eq \"/wp-login.php\"))"
 }
 
 # ---------------------------------------------------------------------------
@@ -43,11 +58,49 @@ resource "cloudflare_ruleset" "gpo_ca_admin_route_protection" {
   kind    = "zone"
   phase   = "http_request_firewall_custom"
 
+  # Endpoints gpo-ca verifiably does not use. Each was confirmed against the
+  # gpo/gpo-ca source rather than assumed from a generic WordPress checklist:
+  #   xmlrpc.php        — not disabled anywhere in code, and nothing calls it
+  #   wp-comments-post  — comments_open is filtered to __return_false site-wide
+  #   wp-signup/register— no public registration; only staff have accounts
+  #   trackback         — pingback/trackback surface, unused with comments off
+  # Blocked outright rather than challenged: a challenge page still costs a
+  # round trip, and there is no legitimate traffic to preserve here.
+  rules {
+    action      = "block"
+    description = "Block unused WordPress endpoints (xmlrpc, comments, signup, trackback)"
+    enabled     = true
+    expression  = "((http.request.uri.path matches \"^(/wordpress)?/xmlrpc\\\\.php$\") or (http.request.uri.path matches \"^(/wordpress)?/wp-comments-post\\\\.php$\") or (http.request.uri.path matches \"^(/wordpress)?/wp-(signup|register)\\\\.php$\") or (http.request.uri.path matches \"/trackback/?$\"))"
+  }
+
+  # WordPress exposes contributors at /wp-json/wp/v2/users and redirects
+  # /?author=<id> to the author archive, both of which leak valid usernames to
+  # feed the credential-stuffing traffic the rules above are meant to raise the
+  # cost of. The theme never queries either, and the only REST namespace the
+  # front end uses is gpo-action-blocks/v1, so neither is load-bearing.
+  rules {
+    action      = "block"
+    description = "Block WordPress user enumeration (REST users endpoint, author archives)"
+    enabled     = true
+    expression  = "((starts_with(http.request.uri.path, \"/wp-json/wp/v2/users\")) or (http.request.uri.query matches \"(^|&)author=[0-9]+\"))"
+  }
+
   rules {
     action      = "managed_challenge"
     description = "Challenge traffic to WordPress admin/login surfaces"
     enabled     = true
     expression  = local.wp_admin_route_expression
+  }
+
+  # Defence in depth against an upload-to-RCE chain. WP_CONTENT_DIR is the web
+  # root here (CONTENT_DIR = ""), so media lands in /uploads, and unlike many
+  # WordPress deployments web/.htaccess has no rule stopping the origin from
+  # executing PHP there. Nothing legitimate serves a .php file out of /uploads.
+  rules {
+    action      = "block"
+    description = "Block PHP execution under /uploads"
+    enabled     = true
+    expression  = "(starts_with(http.request.uri.path, \"/uploads/\") and http.request.uri.path matches \"\\\\.ph(p[0-9]?|tml|ar)$\")"
   }
 
   rules {
@@ -71,7 +124,7 @@ resource "cloudflare_ruleset" "gpo_ca_wp_login_rate_limit" {
     action      = "block"
     description = "Rate limit POST /wp-login.php per source IP"
     enabled     = true
-    expression  = "(http.request.uri.path eq \"/wp-login.php\") and (http.request.method eq \"POST\")"
+    expression  = "${local.wp_login_path_expression} and (http.request.method eq \"POST\")"
 
     ratelimit {
       characteristics     = ["ip.src"]

--- a/tf/infra/singletons/cloudflare_wordpress_admin_protection.tf
+++ b/tf/infra/singletons/cloudflare_wordpress_admin_protection.tf
@@ -1,0 +1,83 @@
+# Harden Cloudflare-level protection for WordPress admin/login surfaces on
+# the gpo.ca zone (gpo.ca, secure.gpo.ca, and any future WordPress site
+# sharing this zone). See docs/cloudflare-waf.md for rationale, threshold
+# choices, and the exception process for admins travelling outside Canada.
+#
+# https://github.com/gpo/gpo-platform-configs/issues/202
+
+locals {
+  # Requests per source IP per minute allowed to POST /wp-login.php before
+  # Cloudflare starts blocking that IP.
+  wp_login_rate_limit_requests_per_minute = 5
+  wp_login_rate_limit_block_seconds       = 600
+
+  # Off by default. Hard-challenging non-CA traffic to admin routes needs the
+  # travelling-admin exception process documented in docs/cloudflare-waf.md
+  # agreed on before it's safe to flip on.
+  restrict_admin_routes_to_canada = false
+
+  # admin-ajax.php lives under /wp-admin but is called by unauthenticated
+  # front-end visitors (contact forms, WooCommerce, etc.), so it's excluded
+  # from admin-route matching to avoid challenging normal site traffic.
+  wp_admin_route_expression = "((http.request.uri.path eq \"/wp-login.php\") or (http.request.uri.path eq \"/xmlrpc.php\") or (starts_with(http.request.uri.path, \"/wp-admin\") and http.request.uri.path ne \"/wp-admin/admin-ajax.php\"))"
+}
+
+# ---------------------------------------------------------------------------
+# Bot Fight Mode — free-tier bot mitigation, zone-wide.
+#
+# Super Bot Fight Mode fields (sbfm_*, optimize_wordpress) are left unset:
+# they're Pro-plan-and-up features and the account's current plan tier
+# hasn't been confirmed. Enable them here once that's known.
+# ---------------------------------------------------------------------------
+resource "cloudflare_bot_management" "gpo_ca" {
+  zone_id    = cloudflare_zone.gpo_ca.id
+  fight_mode = true
+}
+
+# ---------------------------------------------------------------------------
+# WAF custom rules — WordPress admin/login route protection
+# ---------------------------------------------------------------------------
+resource "cloudflare_ruleset" "gpo_ca_admin_route_protection" {
+  zone_id = cloudflare_zone.gpo_ca.id
+  name    = "WordPress admin route protection"
+  kind    = "zone"
+  phase   = "http_request_firewall_custom"
+
+  rules {
+    action      = "managed_challenge"
+    description = "Challenge traffic to WordPress admin/login surfaces"
+    enabled     = true
+    expression  = local.wp_admin_route_expression
+  }
+
+  rules {
+    action      = "managed_challenge"
+    description = "Challenge non-Canadian traffic to WordPress admin/login surfaces"
+    enabled     = local.restrict_admin_routes_to_canada
+    expression  = "${local.wp_admin_route_expression} and (ip.src.country ne \"CA\")"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Rate limiting — throttle POST /wp-login.php per source IP
+# ---------------------------------------------------------------------------
+resource "cloudflare_ruleset" "gpo_ca_wp_login_rate_limit" {
+  zone_id = cloudflare_zone.gpo_ca.id
+  name    = "wp-login.php rate limit"
+  kind    = "zone"
+  phase   = "http_ratelimit"
+
+  rules {
+    action      = "block"
+    description = "Rate limit POST /wp-login.php per source IP"
+    enabled     = true
+    expression  = "(http.request.uri.path eq \"/wp-login.php\") and (http.request.method eq \"POST\")"
+
+    ratelimit {
+      characteristics     = ["ip.src"]
+      period              = 60
+      requests_per_period = local.wp_login_rate_limit_requests_per_minute
+      mitigation_timeout  = local.wp_login_rate_limit_block_seconds
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #202. Adds Cloudflare-level protection for WordPress admin/login surfaces on the `gpo.ca` zone, scoped by path so it covers every WordPress site sharing the zone (`gpo.ca`, `secure.gpo.ca`, and any future subdomain):

- **Bot Fight Mode** (`cloudflare_bot_management.gpo_ca`) — zone-wide, works on any plan tier.
- **Rate limiting** (`cloudflare_ruleset.gpo_ca_wp_login_rate_limit`) — blocks a source IP for 10 minutes after 5 POSTs to `/wp-login.php` within 60 seconds (thresholds are `locals`, easy to tune).
- **WAF custom rule** (`cloudflare_ruleset.gpo_ca_admin_route_protection`) — managed-challenges `/wp-login.php`, `/xmlrpc.php`, and `/wp-admin/*`, deliberately excluding `/wp-admin/admin-ajax.php` since plugins call it from unauthenticated front-end traffic.
- **Geo-scoping to Canada** — wired in as a second WAF rule (managed challenge, not a hard block, for non-CA traffic to admin routes) but shipped **disabled** via `local.restrict_admin_routes_to_canada`. Turning it on needs the travelling-admin exception process the issue calls for, which isn't defined yet.

Rationale, threshold choices, and the open items (plan-tier confirmation for Super Bot Fight Mode, the geo-scoping exception process) are written up in the new `docs/cloudflare-waf.md`, linked from the repo's doc index.

## Test plan

- [ ] CI (`terraform_validate` / `terraform_fmt` / `terraform-docs`) passes on this PR — I don't have `tofu` available locally to pre-validate, so I'll fix anything CI flags.
- [ ] Reviewer confirms current Cloudflare plan tier for `gpo.ca` (Free vs. Pro+) — determines whether Super Bot Fight Mode fields should be added to `cloudflare_bot_management.gpo_ca`.
- [ ] After merge, `tofu plan` reviewed before apply per the repo's plan/apply workflow — this touches a live, unstaged (`singletons`) production zone.
- [ ] Post-apply: confirm `/wp-admin/admin-ajax.php` still resolves normally for anonymous visitors, and that a legitimate login still succeeds under the rate limit.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UDr8K2RPxC9r9NY57yYW6L)_