### PR TITLE
Add GitHub org verification TXT record for gpo.ca

### DIFF
--- a/tf/infra/singletons/cloudflare_domains.tf
+++ b/tf/infra/singletons/cloudflare_domains.tf
@@ -350,6 +350,15 @@ resource "cloudflare_record" "scph1018__domainkey_gpo_ca" {
   ttl     = 300
 }
 
+# GitHub organization domain verification
+resource "cloudflare_record" "_gh_gpo_o_gpo_ca" {
+  zone_id = cloudflare_zone.gpo_ca.id
+  name    = "_gh-gpo-o.gpo.ca"
+  content = "2e873b4c9a"
+  type    = "TXT"
+  ttl     = 300
+}
+
 resource "cloudflare_record" "mar2019__domainkey_lists_gpo_ca" {
   zone_id = cloudflare_zone.gpo_ca.id
   name    = "mar2019._domainkey.lists.gpo.ca"


### PR DESCRIPTION
Adds a TXT record at `_gh-gpo-o.gpo.ca` with value `2e873b4c9a` for GitHub organization domain verification.

- Resource: `cloudflare_record._gh_gpo_o_gpo_ca` in `tf/infra/singletons/cloudflare_domains.tf`
- Full FQDN in `name`, `ttl = 300` (unproxied), per repo conventions

Note: the verification code expires 7 days from issuance, so this needs to be applied and verified in GitHub before then.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmxC4i4RVCSTiQNUVqXv3C)_