### PR TITLE
Fix TLS warning on www.gpo.ca by proxy and redirect to apex

### DIFF
--- a/tf/infra/singletons/README.md
+++ b/tf/infra/singletons/README.md
@@ -88,6 +88,7 @@ will *not* have a separate copy for stage and prod belongs here.
 | [cloudflare_record.web_e_gpo_ca](https://registry.terraform.io/providers/cloudflare/cloudflare/4.48.0/docs/resources/record) | resource |
 | [cloudflare_record.www_gpo_ca](https://registry.terraform.io/providers/cloudflare/cloudflare/4.48.0/docs/resources/record) | resource |
 | [cloudflare_record.www_islandgetaway_ca](https://registry.terraform.io/providers/cloudflare/cloudflare/4.48.0/docs/resources/record) | resource |
+| [cloudflare_ruleset.www_gpo_ca_redirect](https://registry.terraform.io/providers/cloudflare/cloudflare/4.48.0/docs/resources/ruleset) | resource |
 | [cloudflare_ruleset.www_islandgetaway_ca_redirect](https://registry.terraform.io/providers/cloudflare/cloudflare/4.48.0/docs/resources/ruleset) | resource |
 | [cloudflare_zone.gpo_ca](https://registry.terraform.io/providers/cloudflare/cloudflare/4.48.0/docs/resources/zone) | resource |
 | [cloudflare_zone.islandgetaway_ca](https://registry.terraform.io/providers/cloudflare/cloudflare/4.48.0/docs/resources/zone) | resource |

--- a/tf/infra/singletons/cloudflare_domains.tf
+++ b/tf/infra/singletons/cloudflare_domains.tf
@@ -112,12 +112,42 @@ resource "cloudflare_record" "_28200265_gpo_ca" {
   ttl     = 300
 }
 
+# Proxied so Cloudflare's Universal SSL cert (gpo.ca + *.gpo.ca) terminates TLS
+# at the edge. DNS-only sent browsers straight to the origin, which only holds a
+# cert for the apex, producing a certificate-name-mismatch warning on www.
 resource "cloudflare_record" "www_gpo_ca" {
   zone_id = cloudflare_zone.gpo_ca.id
   name    = "www.gpo.ca"
   content = "gpo.ca"
   type    = "CNAME"
-  ttl     = 300
+  ttl     = 1
+  proxied = true
+}
+
+# 301 www → apex, preserving path and query string
+resource "cloudflare_ruleset" "www_gpo_ca_redirect" {
+  zone_id = cloudflare_zone.gpo_ca.id
+  name    = "Redirect www to apex"
+  kind    = "zone"
+  phase   = "http_request_dynamic_redirect"
+
+  rules {
+    action      = "redirect"
+    expression  = "(http.host eq \"www.gpo.ca\")"
+    description = "301 www.gpo.ca -> gpo.ca"
+    enabled     = true
+
+    action_parameters {
+      from_value {
+        status_code           = 301
+        preserve_query_string = true
+
+        target_url {
+          expression = "concat(\"https://gpo.ca\", http.request.uri.path)"
+        }
+      }
+    }
+  }
 }
 
 resource "cloudflare_record" "agmsurvey_gpo_ca" {


### PR DESCRIPTION
## Problem

Scanning a QR code that points at `https://www.gpo.ca` shows a browser interstitial ("Your connection is not private", certificate name mismatch). `https://gpo.ca` is fine.

Cause: `cloudflare_record.www_gpo_ca` was a **DNS-only** CNAME (`proxied` unset, so false). Cloudflare returned the origin IP directly, the browser connected to `143.244.200.166`, and that origin only presents a certificate for the apex. No SAN for `www.gpo.ca` → mismatch. Cloudflare's Universal SSL certificate was never in the path because the record was grey-clouded.

## Changes

- `tf/infra/singletons/cloudflare_domains.tf`
  - `www_gpo_ca`: `proxied = true`, `ttl = 1`. TLS now terminates at Cloudflare's edge, where the Universal SSL certificate covers `gpo.ca` and `*.gpo.ca`.
  - New `cloudflare_ruleset.www_gpo_ca_redirect`: 301 `www.gpo.ca` → `https://gpo.ca`, preserving path and query string. Same shape as the existing `www_islandgetaway_ca_redirect`.
- `tf/infra/singletons/README.md`: added the new ruleset to the generated resource table.

## Notes

- `singletons` is production-only, so this is live on apply. Propagation is near-immediate for new resolvers; the old record had a 300s TTL, so cached grey-cloud answers clear within five minutes.
- The printed postcards need no reprint once this is applied.
- Worth confirming Universal SSL is active on the zone before applying; if it were ever disabled, the edge would have no certificate for `www` either.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkTvdEJ4Wi6qrdGLu5L36C)_