### PR TITLE
Pin CI's OpenTofu version to match .mise.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
 
       - name: Set up OpenTofu
         uses: opentofu/setup-opentofu@v1
+        with:
+          # keep in sync with .mise.toml's `opentofu` version - a mismatch
+          # here causes spurious lock-file diffs on any PR touching *.tf
+          tofu_version: '1.9.1'
 
       - name: Use OpenTofu for Terraform
         run: echo "PCT_TFPATH=$(which tofu)" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
- `setup-opentofu@v1` was defaulting to `tofu_version: latest`, while `.mise.toml` pins `opentofu = '1.9.1'` for local dev
- That mismatch caused two spurious `terraform_validate` lock-file-diff failures on unrelated PRs (#207, #208) — CI's `latest` resolves different provider hashes than the locally-pinned version, so any PR touching a `.tf` file triggers a "files were modified by this hook" failure that has nothing to do with the PR's actual content
- Pins CI to `1.9.1` to match, with a comment noting to keep them in sync on future bumps

## Test plan
- [ ] Confirm this CI run itself passes without a lock-file diff
- [ ] Confirm a future PR touching `.tf` files doesn't trigger the same spurious failure


---
_Generated by [Claude Code](https://claude.ai/code/session_01JciC8rqCAN4sL5EEjUCsta)_