### PR TITLE
Retarget canopy Application from the deleted branch to HEAD

### DIFF
--- a/kubernetes/argocd-apps/stage/application.yaml
+++ b/kubernetes/argocd-apps/stage/application.yaml
@@ -14,10 +14,10 @@ spec:
   sources:
   - path: kubernetes/canopy/resources
     repoURL: https://github.com/gpo/gpo-platform-configs
-    targetRevision: canopy-app-scaffolding
+    targetRevision: HEAD
   - path: kubernetes/canopy/stage/rendered
     repoURL: https://github.com/gpo/gpo-platform-configs
-    targetRevision: canopy-app-scaffolding
+    targetRevision: HEAD
   syncPolicy:
     syncOptions:
       - CreateNamespace=true


### PR DESCRIPTION
## Summary

`kubernetes/argocd-apps/stage/application.yaml`'s `canopy` Application still pointed both `sources` entries at `canopy-app-scaffolding`, which was squash-merged as #207 and then deleted. ArgoCD's sync for `canopy` has likely been failing since that merge, since its source branch no longer exists.

Retargets both entries to `HEAD`, matching every other `Application` in this file.

Urgent/standalone on purpose — unrelated to #208 (still blocked on confirming the `gpogear.ca` Cloudflare/domain situation), so this shouldn't wait on that.

## Test plan
- [ ] Confirm the `canopy` Application in the ArgoCD UI goes back to `Synced` (not erroring on a missing revision) after this merges


---
_Generated by [Claude Code](https://claude.ai/code/session_01JciC8rqCAN4sL5EEjUCsta)_